### PR TITLE
refactor(core): align EIP-712 structures with whitepaper concepts

### DIFF
--- a/client/components/business/Publication/List.jsx
+++ b/client/components/business/Publication/List.jsx
@@ -12,7 +12,7 @@ import {
 import { SEARCH_PUBLICATIONS } from "../../../graphql/queries"
 import { useTranslation } from "../../../hooks/useTranslation"
 import { useWallet } from "../../../hooks/useWallet"
-import { contentSignatureTypedData } from "../../../utils/eip712"
+import { statementOfSourceTypedData } from "../../../utils/eip712"
 import { ConfirmDialog, InfoDialog, LoadingSkeleton } from "../../ui"
 import { toaster } from "../../ui/toaster"
 import { PublicationItem } from "./Item"
@@ -120,7 +120,7 @@ const PublicationList = ({
 
     try {
       // 使用实际的内容哈希，而不是重新计算
-      const typedData = contentSignatureTypedData(
+      const typedData = statementOfSourceTypedData(
         publication.content.content_hash,
         publication.author.address,
         Math.floor(new Date(publication.created_at).getTime() / 1000), // 使用 publication 的创建时间

--- a/client/hooks/usePublicationDetail.js
+++ b/client/hooks/usePublicationDetail.js
@@ -9,7 +9,7 @@ import {
   UPDATE_PUBLICATION,
 } from "../graphql/mutations"
 import { FETCH } from "../graphql/queries"
-import { contentSignatureTypedData } from "../utils/eip712"
+import { statementOfSourceTypedData } from "../utils/eip712"
 import { useTranslation } from "./useTranslation"
 import { useWallet } from "./useWallet"
 
@@ -134,7 +134,7 @@ export function usePublicationDetail() {
 
     try {
       // 创建EIP-712签名数据
-      const typedData = contentSignatureTypedData(
+      const typedData = statementOfSourceTypedData(
         publication.content.content_hash,
         publication.author.address,
         Math.floor(new Date(publication.created_at).getTime() / 1000), // 使用 publication 的创建时间

--- a/client/utils/eip712.js
+++ b/client/utils/eip712.js
@@ -70,7 +70,7 @@ export const deleteConnectionTypedData = (
 }
 
 // 内容签名的EIP-712数据结构
-export const contentSignatureTypedData = (
+export const statementOfSourceTypedData = (
   contentHash,
   publisherAddress,
   timestamp,
@@ -81,14 +81,14 @@ export const contentSignatureTypedData = (
       version: "1",
       chainId: 1,
     },
-    primaryType: "ContentSignature",
+    primaryType: "StatementOfSource",
     types: {
       EIP712Domain: [
         { name: "name", type: "string" },
         { name: "version", type: "string" },
         { name: "chainId", type: "uint256" },
       ],
-      ContentSignature: [
+      StatementOfSource: [
         { name: "contentHash", type: "bytes32" },
         { name: "publisherAddress", type: "address" },
         { name: "timestamp", type: "uint64" },

--- a/server/models/node.mjs
+++ b/server/models/node.mjs
@@ -409,29 +409,13 @@ export class Node extends Model {
                     continue
                   }
 
-                  // 构造 typedData - publisherAddress 应该是被同步节点的地址
-                  const typedData = {
-                    domain: { name: "epress world", version: "1", chainId: 1 },
-                    types: {
-                      ContentSignature: [
-                        { name: "contentHash", type: "bytes32" },
-                        { name: "publisherAddress", type: "address" },
-                        { name: "timestamp", type: "uint64" },
-                      ],
-                    },
-                    primaryType: "ContentSignature",
-                    message: {
-                      contentHash: pub.content_hash,
-                      publisherAddress: pub.author_address, // 使用 pub.author_address 作为被同步节点的地址
-                      timestamp: Math.floor(
-                        new Date(pub.created_at).getTime() / 1000,
-                      ), // 使用 publication 的创建时间
-                    },
-                  }
-
                   // 使用 syncPublication 方法同步单个内容
                   const syncResult = await this.sync.publication(
-                    typedData,
+                    Publication.createStatementOfSource(
+                      pub.content_hash,
+                      pub.author_address,
+                      Math.floor(new Date(pub.created_at).getTime() / 1000),
+                    ),
                     pub.signature,
                     { timeout },
                   )

--- a/server/models/publication.mjs
+++ b/server/models/publication.mjs
@@ -81,4 +81,40 @@ export class Publication extends Model {
 
     return count
   }
+
+  get statementOfSource() {
+    return Publication.createStatementOfSource(
+      this.content_hash,
+      this.author_address,
+      Math.floor(new Date(this.created_at).getTime() / 1000),
+    )
+  }
+
+  static createStatementOfSource(contentHash, publisherAddress, timestamp) {
+    return {
+      domain: {
+        name: "epress world",
+        version: "1",
+        chainId: 1,
+      },
+      primaryType: "StatementOfSource",
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+        ],
+        StatementOfSource: [
+          { name: "contentHash", type: "bytes32" },
+          { name: "publisherAddress", type: "address" },
+          { name: "timestamp", type: "uint64" },
+        ],
+      },
+      message: {
+        contentHash,
+        publisherAddress,
+        timestamp,
+      },
+    }
+  }
 }

--- a/server/routes/ewp/replications.mjs
+++ b/server/routes/ewp/replications.mjs
@@ -97,22 +97,11 @@ router.post("/replications", async (request, reply) => {
 
   try {
     // 5. 构造 typedData 并使用 publisherNode.sync.publication 方法同步内容
-    const syncTypedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: publisherNode.address,
-        timestamp: typedData.message.timestamp, // 使用传入的时间戳（来自 publication.created_at）
-      },
-    }
+    const syncTypedData = Publication.createStatementOfSource(
+      contentHash,
+      publisherNode.address,
+      typedData.message.timestamp,
+    )
 
     const syncResult = await publisherNode.sync.publication(
       syncTypedData,

--- a/test/models/node.test.mjs
+++ b/test/models/node.test.mjs
@@ -44,23 +44,13 @@ test.serial(
     const textContent = "# Test Post\n\nThis is a test post."
     const contentHash = await calculateContentHash(textContent)
 
+    const createdAt = new Date()
     // 生成有效的签名
-    const typedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: TEST_ACCOUNT_NODE_A.address,
-        timestamp: Math.floor(Date.now() / 1000), // 使用当前时间戳
-      },
-    }
+    const typedData = Publication.createStatementOfSource(
+      contentHash,
+      TEST_ACCOUNT_NODE_A.address,
+      Math.floor(createdAt.getTime() / 1000),
+    )
     const signature = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData,
@@ -82,7 +72,7 @@ test.serial(
             author_address: testNode.address,
             signature: signature,
             comment_count: 5,
-            created_at: new Date().toISOString(),
+            created_at: createdAt.toISOString(),
           },
         ],
         pagination: {
@@ -166,22 +156,11 @@ test.serial(
     const contentHash = await calculateContentHash(fileContent.toString())
 
     // 生成有效的签名
-    const typedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: TEST_ACCOUNT_NODE_A.address,
-        timestamp: Math.floor(Date.now() / 1000), // 使用当前时间戳
-      },
-    }
+    const typedData = Publication.createStatementOfSource(
+      contentHash,
+      TEST_ACCOUNT_NODE_A.address,
+      Math.floor(Date.now() / 1000),
+    )
     const signature = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData,
@@ -340,44 +319,22 @@ test.serial(
     const contentHash2 = await calculateContentHash(textContent2)
 
     // 生成有效的签名
-    const typedData1 = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash1,
-        publisherAddress: testNode.address,
-        timestamp: Math.floor(Date.now() / 1000), // 添加时间戳
-      },
-    }
+    const typedData1 = Publication.createStatementOfSource(
+      contentHash1,
+      testNode.address,
+      Math.floor(Date.now() / 1000),
+    )
     const signature1 = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData1,
       "typedData",
     )
 
-    const typedData2 = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash2,
-        publisherAddress: testNode.address,
-        timestamp: Math.floor(Date.now() / 1000), // 添加时间戳
-      },
-    }
+    const typedData2 = Publication.createStatementOfSource(
+      contentHash2,
+      testNode.address,
+      Math.floor(Date.now() / 1000),
+    )
     const signature2 = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData2,
@@ -491,22 +448,11 @@ test.serial(
     const contentHash2 = await calculateContentHash(textContent2)
 
     // 生成有效的签名
-    const typedData1 = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash1,
-        publisherAddress: testNode.address,
-        timestamp: Math.floor(Date.now() / 1000), // 添加时间戳
-      },
-    }
+    const typedData1 = Publication.createStatementOfSource(
+      contentHash1,
+      testNode.address,
+      Math.floor(Date.now() / 1000),
+    )
     const signature1 = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData1,
@@ -597,22 +543,11 @@ test.serial(
     const contentHash = await calculateContentHash(textContent)
 
     // 生成有效的签名
-    const typedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: TEST_ACCOUNT_NODE_A.address,
-        timestamp: Math.floor(Date.now() / 1000), // 使用当前时间戳
-      },
-    }
+    const typedData = Publication.createStatementOfSource(
+      contentHash,
+      TEST_ACCOUNT_NODE_A.address,
+      Math.floor(Date.now() / 1000),
+    )
     const signature = await generateSignature(
       TEST_ACCOUNT_NODE_A,
       typedData,
@@ -695,22 +630,11 @@ test.serial("Node.sync.publication should skip existing content", async (t) => {
   })
 
   // 生成有效的签名
-  const typedData = {
-    domain: { name: "epress world", version: "1", chainId: 1 },
-    types: {
-      ContentSignature: [
-        { name: "contentHash", type: "bytes32" },
-        { name: "publisherAddress", type: "address" },
-        { name: "timestamp", type: "uint64" },
-      ],
-    },
-    primaryType: "ContentSignature",
-    message: {
-      contentHash: contentHash,
-      publisherAddress: TEST_ACCOUNT_NODE_A.address,
-      timestamp: Math.floor(created_at.getTime() / 1000), // 使用当前时间戳created_at,
-    },
-  }
+  const typedData = Publication.createStatementOfSource(
+    contentHash,
+    TEST_ACCOUNT_NODE_A.address,
+    Math.floor(created_at.getTime() / 1000),
+  )
   const signature = await generateSignature(
     TEST_ACCOUNT_NODE_A,
     typedData,
@@ -743,22 +667,11 @@ test.serial(
     const contentHash = await calculateContentHash("test content")
 
     // 构造 typedData
-    const typedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: TEST_ACCOUNT_NODE_A.address,
-        timestamp: Math.floor(Date.now() / 1000), // 使用当前时间戳
-      },
-    }
+    const typedData = Publication.createStatementOfSource(
+      contentHash,
+      TEST_ACCOUNT_NODE_A.addres,
+      Math.floor(Date.now() / 1000),
+    )
 
     // Act: 执行同步（不提供签名）
     const result = await testNode.sync.publication(typedData, null)
@@ -792,22 +705,11 @@ test.serial(
     const invalidSignature = "0xinvalid1234567890"
 
     // 构造 typedData
-    const typedData = {
-      domain: { name: "epress world", version: "1", chainId: 1 },
-      types: {
-        ContentSignature: [
-          { name: "contentHash", type: "bytes32" },
-          { name: "publisherAddress", type: "address" },
-          { name: "timestamp", type: "uint64" },
-        ],
-      },
-      primaryType: "ContentSignature",
-      message: {
-        contentHash: contentHash,
-        publisherAddress: TEST_ACCOUNT_NODE_A.address,
-        timestamp: Math.floor(Date.now() / 1000), // 使用当前时间戳
-      },
-    }
+    const typedData = Publication.createStatementOfSource(
+      contentHash,
+      TEST_ACCOUNT_NODE_A.address,
+      Math.floor(Date.now() / 1000),
+    )
 
     // Act: 执行同步（提供无效签名）
     const result = await testNode.sync.publication(typedData, invalidSignature)


### PR DESCRIPTION
- Renames the EIP-712 `PrimaryType` for content signing from `ContentSignature` to `StatementOfSource`.
- Introduces a `Publication.createStatementOfSource` static method and a `statementOfSource` getter to centralize the creation of this typed data structure.
- Refactors all related frontend, backend, and test files to use the new terminology and centralized methods.
- This change improves code clarity and aligns the implementation with the concepts defined in the whitepaper.

Closes #4