### PR TITLE
fix(client): Correct 'No more' message visibility in list components

### DIFF
--- a/client/components/business/Comment/List.jsx
+++ b/client/components/business/Comment/List.jsx
@@ -12,6 +12,7 @@ import { CommentItem } from "./Item"
 
 const CommentList = ({ publicationId, onCommentDeleted }) => {
   const [hasMore, setHasMore] = useState(true)
+  const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
   const { common } = useTranslation()
 
   // 获取评论列表 - 使用 Apollo Client
@@ -55,6 +56,7 @@ const CommentList = ({ publicationId, onCommentDeleted }) => {
     if (!hasMore || loading) return
 
     try {
+      setHasAttemptedLoadMore(true)
       await fetchMore({
         variables: {
           after: data?.search?.pageInfo?.endCursor,
@@ -108,7 +110,7 @@ const CommentList = ({ publicationId, onCommentDeleted }) => {
       ))}
 
       {hasMore && (
-        <HStack justify="center" py={4}>
+        <HStack justify="center" py={1}>
           <Button
             onClick={loadMore}
             loading={loading}
@@ -124,7 +126,7 @@ const CommentList = ({ publicationId, onCommentDeleted }) => {
         </HStack>
       )}
 
-      {!hasMore && comments.length > 0 && (
+      {!hasMore && comments.length > 0 && hasAttemptedLoadMore && (
         <Text textAlign="center" color="gray.500" py={4}>
           {common.noMore()}
         </Text>

--- a/client/components/business/Connection/FollowersList.jsx
+++ b/client/components/business/Connection/FollowersList.jsx
@@ -129,7 +129,7 @@ export function FollowersList({ initialData, loading, error, onRefetch }) {
         </Box>
       )}
 
-      {!hasMore && followers.length > 0 && (
+      {!hasMore && followers.length > 0 && page > 1 && (
         <Box textAlign="center" py={4}>
           <Text color="gray.400" _dark={{ color: "gray.500" }} fontSize="sm">
             {common.noMore()}

--- a/client/components/business/Connection/FollowingList.jsx
+++ b/client/components/business/Connection/FollowingList.jsx
@@ -22,6 +22,7 @@ import { toaster } from "../../ui/toaster"
 
 const FollowingList = ({ initialData, loading, error }) => {
   const [hasMore, setHasMore] = useState(true)
+  const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
   const [selectedNode, setSelectedNode] = useState(null)
   const [isOpen, setIsOpen] = useState(false)
   const { isNodeOwner } = useAuth()
@@ -70,6 +71,7 @@ const FollowingList = ({ initialData, loading, error }) => {
     if (!hasMore || loading) return
 
     try {
+      setHasAttemptedLoadMore(true)
       await fetchMore({
         variables: {
           after: data?.search?.pageInfo?.endCursor,
@@ -273,7 +275,7 @@ const FollowingList = ({ initialData, loading, error }) => {
           </HStack>
         )}
 
-        {!hasMore && following.length > 0 && (
+        {!hasMore && following.length > 0 && hasAttemptedLoadMore && (
           <Text
             textAlign="center"
             color="gray.400"

--- a/client/components/business/Publication/List.jsx
+++ b/client/components/business/Publication/List.jsx
@@ -27,6 +27,7 @@ const PublicationList = ({
   const { signEIP712Data } = useWallet()
   const { publication: pub, common } = useTranslation()
   const [hasMore, setHasMore] = useState(true)
+  const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
 
   // 对话框状态
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -77,6 +78,7 @@ const PublicationList = ({
     if (!hasMore || loading) return
 
     try {
+      setHasAttemptedLoadMore(true)
       await fetchMore({
         variables: {
           after: data?.search?.pageInfo?.endCursor,
@@ -288,7 +290,7 @@ const PublicationList = ({
           </HStack>
         )}
 
-        {!hasMore && publications.length > 0 && (
+        {!hasMore && publications.length > 0 && hasAttemptedLoadMore && (
           <Text
             textAlign="center"
             color="gray.500"


### PR DESCRIPTION
This commit addresses the issue where the "No more" message was displayed incorrectly in various list components. The visibility logic has been updated to ensure the message only appears after an attempt to load more data has been made, or when there is more than one page of content.

Affected components:
- client/components/business/Comment/List.jsx
- client/components/business/Connection/FollowersList.jsx
- client/components/business/Connection/FollowingList.jsx
- client/components/business/Publication/List.jsx

Closes #14