### PR TITLE
fix(client): Ensure UI updates after identity and connection changes

### DIFF
--- a/client/hooks/useConnection.js
+++ b/client/hooks/useConnection.js
@@ -5,6 +5,7 @@ import { useAccount } from "wagmi"
 import { toaster } from "../components/ui/toaster"
 import { useAuth } from "../contexts/AuthContext"
 import { CREATE_CONNECTION, DESTROY_CONNECTION } from "../graphql/mutations"
+import { SEARCH_NODES } from "../graphql/queries"
 import {
   createConnectionTypedData,
   deleteConnectionTypedData,
@@ -105,6 +106,17 @@ export function useConnection() {
           typedData,
           signature: signature,
         },
+        refetchQueries: [
+          {
+            query: SEARCH_NODES,
+            variables: {
+              filterBy: { type: "followers" },
+              orderBy: "-created_at",
+              first: 20,
+            },
+          },
+        ],
+        awaitRefetchQueries: true,
       })
 
       toaster.create({
@@ -163,6 +175,17 @@ export function useConnection() {
           typedData,
           signature: signature,
         },
+        refetchQueries: [
+          {
+            query: SEARCH_NODES,
+            variables: {
+              filterBy: { type: "followers" },
+              orderBy: "-created_at",
+              first: 20,
+            },
+          },
+        ],
+        awaitRefetchQueries: true,
       })
 
       toaster.create({


### PR DESCRIPTION
This commit resolves the issue where the UI did not automatically update after changes to the viewer's identity (e.g., login, logout) or connection status (e.g., follow, unfollow).

Changes include:
- In `AuthContext.jsx`, implemented Apollo Client cache clearing and active query refetching upon successful login and logout to ensure immediate UI reflection of identity changes.
- In `useConnection.js`, added `refetchQueries` to `createConnection` and `destroyConnection` mutations to automatically refetch relevant data (specifically follower lists) after a follow or unfollow action, ensuring the UI reflects connection changes.

Closes #11