### PR TITLE
feat(client, auth): Implement SSR and migrate auth to HttpOnly cookies

### DIFF
--- a/client/app/api/auth/token/route.js
+++ b/client/app/api/auth/token/route.js
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server"
+
+export async function POST(request) {
+  try {
+    const { token } = await request.json()
+    if (!token || typeof token !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "Invalid token" },
+        { status: 400 },
+      )
+    }
+
+    const res = NextResponse.json({ ok: true })
+    res.cookies.set({
+      name: "authToken",
+      value: token,
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 60 * 60 * 24, // 1 day; server also enforces expiry
+    })
+    return res
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Failed to set cookie" },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ ok: true })
+  res.cookies.set({
+    name: "authToken",
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 0,
+  })
+  return res
+}
+
+// 返回是否存在 HttpOnly authToken，用于客户端检测登录状态
+export async function GET(request) {
+  try {
+    const cookieHeader = request.headers.get("cookie") || ""
+    const match = cookieHeader.match(/(?:^|;\s*)authToken=([^;]+)/)
+    const token = match ? decodeURIComponent(match[1]) : null
+
+    return NextResponse.json({ authenticated: Boolean(token) }, { status: 200 })
+  } catch {
+    return NextResponse.json({ authenticated: false }, { status: 200 })
+  }
+}

--- a/client/app/connections/page.client.jsx
+++ b/client/app/connections/page.client.jsx
@@ -1,0 +1,65 @@
+"use client"
+import { Heading, HStack, Text, VStack } from "@chakra-ui/react"
+import { FollowersList, FollowingList } from "../../components/business"
+import { UnifiedCard } from "../../components/ui"
+import { usePageTitle } from "../../hooks/usePageTitle"
+import { useTranslation } from "../../hooks/useTranslation"
+
+export default function ClientPage({
+  initialFollowersData,
+  initialFollowingData,
+  initialFollowersTotal,
+  initialFollowingTotal,
+}) {
+  const { connection, common } = useTranslation()
+
+  usePageTitle(common.pageTitle.connections())
+
+  return (
+    <VStack spacing={6} align="stretch">
+      <UnifiedCard.Root>
+        <UnifiedCard.Header pb={2}>
+          <HStack justify="space-between" align="center">
+            <Heading size="lg" color="gray.700">
+              {connection.followers()}
+            </Heading>
+            <Text
+              fontSize="lg"
+              fontWeight="bold"
+              fontStyle="italic"
+              color="gray.400"
+              _dark={{ color: "gray.600" }}
+            >
+              {initialFollowersTotal}
+            </Text>
+          </HStack>
+        </UnifiedCard.Header>
+        <UnifiedCard.Body pt={0}>
+          <FollowersList initialData={initialFollowersData} />
+        </UnifiedCard.Body>
+      </UnifiedCard.Root>
+
+      <UnifiedCard.Root>
+        <UnifiedCard.Header pb={2}>
+          <HStack justify="space-between" align="center">
+            <Heading size="lg" color="gray.700">
+              {connection.following()}
+            </Heading>
+            <Text
+              fontSize="lg"
+              fontWeight="bold"
+              fontStyle="italic"
+              color="gray.400"
+              _dark={{ color: "gray.600" }}
+            >
+              {initialFollowingTotal}
+            </Text>
+          </HStack>
+        </UnifiedCard.Header>
+        <UnifiedCard.Body pt={0}>
+          <FollowingList initialData={initialFollowingData} />
+        </UnifiedCard.Body>
+      </UnifiedCard.Root>
+    </VStack>
+  )
+}

--- a/client/app/connections/page.jsx
+++ b/client/app/connections/page.jsx
@@ -1,136 +1,49 @@
-"use client"
-import { useQuery } from "@apollo/client/react"
-import { Box, Heading, HStack, Text, VStack } from "@chakra-ui/react"
-import { FollowersList, FollowingList } from "../../components/business"
-import { LoadingSkeleton, UnifiedCard } from "../../components/ui"
-import { SEARCH_NODES } from "../../graphql/queries"
-import { usePageTitle } from "../../hooks/usePageTitle"
-import { useTranslation } from "../../hooks/useTranslation"
+import PreloadApolloCache from "../../components/util/PreloadApolloCache"
+import {
+  executeServerQueries,
+  getRequestApolloClient,
+} from "../../graphql/index"
+import { CONNECTIONS_PAGE_DATA } from "../../graphql/queries"
+import ClientPage from "./page.client"
 
-export default function ConnectionsPage() {
-  const { connection, common } = useTranslation()
+export default async function ConnectionsServerPage() {
+  const client = getRequestApolloClient()
+  const { data: serverDataMap } = await executeServerQueries(
+    [
+      {
+        queryKey: "CONNECTIONS_PAGE_DATA",
+        query: CONNECTIONS_PAGE_DATA,
+        variables: {
+          orderBy: "-created_at",
+          followersFirst: 20,
+          followingFirst: 20,
+        },
+      },
+    ],
+    client,
+  )
 
-  // 设置页面标题
-  usePageTitle(common.pageTitle.connections())
+  const combined = serverDataMap?.CONNECTIONS_PAGE_DATA?.data || null
+  const followersInitial = combined?.followers
+    ? { search: combined.followers }
+    : null
+  const followingInitial = combined?.following
+    ? { search: combined.following }
+    : null
 
-  // 统一查询两个列表的数据
-  const {
-    data: followersData,
-    loading: followersLoading,
-    error: followersError,
-  } = useQuery(SEARCH_NODES, {
-    variables: {
-      filterBy: { type: "followers" },
-      orderBy: "-created_at",
-      first: 20,
-    },
-    fetchPolicy: "cache-and-network",
-  })
-
-  const {
-    data: followingData,
-    loading: followingLoading,
-    error: followingError,
-  } = useQuery(SEARCH_NODES, {
-    variables: {
-      filterBy: { type: "following" },
-      orderBy: "-created_at",
-      first: 20,
-    },
-    fetchPolicy: "cache-and-network",
-  })
-
-  // 获取总数
-  const followersTotal = followersData?.search?.total || 0
-  const followingTotal = followingData?.search?.total || 0
-
-  // 页面级加载状态
-  const isLoading = followersLoading || followingLoading
-  const hasError = followersError || followingError
-
-  // 如果任一列表正在加载，显示页面级加载状态
-  if (isLoading && !followersData && !followingData) {
-    return <LoadingSkeleton count={6} />
-  }
-
-  // 如果有错误，显示错误信息
-  if (hasError) {
-    return (
-      <VStack spacing={4} py={8}>
-        <Heading size="lg" color="red.500">
-          {common.loadFailed()}
-        </Heading>
-        <Box textAlign="center">
-          {followersError && (
-            <Box color="red.500" mb={2}>
-              {connection.followers()}: {followersError.message}
-            </Box>
-          )}
-          {followingError && (
-            <Box color="red.500">
-              {connection.following()}: {followingError.message}
-            </Box>
-          )}
-        </Box>
-      </VStack>
-    )
-  }
+  const followersTotal = followersInitial?.search?.total || 0
+  const followingTotal = followingInitial?.search?.total || 0
 
   return (
-    <VStack spacing={6} align="stretch">
-      {/* 关注我的 */}
-      <UnifiedCard.Root>
-        <UnifiedCard.Header pb={2}>
-          <HStack justify="space-between" align="center">
-            <Heading size="lg" color="gray.700">
-              {connection.followers()}
-            </Heading>
-            <Text
-              fontSize="lg"
-              fontWeight="bold"
-              fontStyle="italic"
-              color="gray.400"
-              _dark={{ color: "gray.600" }}
-            >
-              {followersTotal}
-            </Text>
-          </HStack>
-        </UnifiedCard.Header>
-        <UnifiedCard.Body pt={0}>
-          <FollowersList
-            initialData={followersData}
-            loading={followersLoading}
-            error={followersError}
-          />
-        </UnifiedCard.Body>
-      </UnifiedCard.Root>
-
-      {/* 我关注的 */}
-      <UnifiedCard.Root>
-        <UnifiedCard.Header pb={2}>
-          <HStack justify="space-between" align="center">
-            <Heading size="lg" color="gray.700">
-              {connection.following()}
-            </Heading>
-            <Text
-              fontSize="lg"
-              fontWeight="bold"
-              fontStyle="italic"
-              color="gray.400"
-              _dark={{ color: "gray.600" }}
-            >
-              {followingTotal}
-            </Text>
-          </HStack>
-        </UnifiedCard.Header>
-        <UnifiedCard.Body pt={0}>
-          <FollowingList
-            initialData={followingData}
-            loading={followingLoading}
-            error={followingError}
-          />
-        </UnifiedCard.Body>
-      </UnifiedCard.Root>
-    </VStack>
+    <>
+      {/* 将服务器端数据预加载到 Apollo 缓存 */}
+      <PreloadApolloCache serverDataMap={serverDataMap} />
+      <ClientPage
+        initialFollowersData={followersInitial}
+        initialFollowingData={followingInitial}
+        initialFollowersTotal={followersTotal}
+        initialFollowingTotal={followingTotal}
+      />
+    </>
   )
 }

--- a/client/app/layout.jsx
+++ b/client/app/layout.jsx
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers"
 import { Page } from "../components/layout"
 import { PwaRegistry } from "../components/ui/PwaRegistry"
 import { executeServerQueries, getRequestApolloClient } from "../graphql"
@@ -49,6 +50,10 @@ export const viewport = {
 }
 
 export default async function RootLayout({ children }) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get("authToken")?.value
+  const authorization = token ? `Bearer ${token}` : ""
+
   // 服务器端配置
   const runtimeConfig = {
     defaultTheme: process.env.EPRESS_CLIENT_DEFAULT_THEME,
@@ -66,7 +71,7 @@ export default async function RootLayout({ children }) {
   ]
 
   // 为本次请求获取可复用的 ApolloClient，并传入批量查询
-  const requestClient = getRequestApolloClient()
+  const requestClient = getRequestApolloClient({ authorization })
   const { data: serverDataMap, errors: serverErrors } =
     await executeServerQueries(globalQueryConfigs, requestClient)
 

--- a/client/app/publications/[id]/page.client.jsx
+++ b/client/app/publications/[id]/page.client.jsx
@@ -1,0 +1,197 @@
+"use client"
+import { Alert, Separator, Text, VStack } from "@chakra-ui/react"
+import { useState } from "react"
+import {
+  CommentForm,
+  CommentList,
+  PublicationEditForm,
+  PublicationItem,
+} from "../../../components/business"
+import {
+  ConfirmDialog,
+  InfoDialog,
+  LoadingSkeleton,
+  UnifiedCard,
+} from "../../../components/ui"
+import { usePage } from "../../../contexts/PageContext"
+import { usePageTitle } from "../../../hooks/usePageTitle"
+import { usePublicationDetail } from "../../../hooks/usePublicationDetail"
+import { useTranslation } from "../../../hooks/useTranslation"
+import { stripMarkdown, truncateText } from "../../../utils/textUtils"
+
+export default function PublicationDetailPage({ initialPublication = null }) {
+  const { common } = useTranslation()
+  const { settings } = usePage()
+  const [localPendingComment, setLocalPendingComment] = useState(null)
+  const [retrySignatureFn, setRetrySignatureFn] = useState(null)
+  const [commentRefetch, setCommentRefetch] = useState(null)
+  const {
+    publicationId,
+    isEditMode,
+    publication,
+    publicationLoading,
+    publicationError,
+    deleteDialogOpen,
+    signatureDialogOpen,
+    signatureInfo,
+    isDeleting,
+    authStatus,
+    isNodeOwner,
+    handleEdit,
+    handleCancelEdit,
+    handleSaveEdit,
+    handleSignPublication,
+    handleDeleteClick,
+    handleConfirmDelete,
+    handleShowSignature,
+    handleCommentCreated,
+    setDeleteDialogOpen,
+    setSignatureDialogOpen,
+  } = usePublicationDetail({ initialPublication })
+
+  // 生成页面标题
+  const getPageTitle = () => {
+    if (!publication) return common.pageTitle.contentDetail()
+
+    let textToTruncate = ""
+    if (publication.content?.type === "FILE") {
+      textToTruncate = publication.description || ""
+    } else {
+      textToTruncate = publication.content?.body || ""
+    }
+
+    if (!textToTruncate) return common.pageTitle.contentDetail()
+
+    const plainText = stripMarkdown(textToTruncate)
+    const truncatedText = truncateText(plainText, 30)
+    return truncatedText
+  }
+
+  // 设置页面标题 - 必须在所有条件渲染之前
+  usePageTitle(getPageTitle())
+
+  if (publicationLoading) {
+    return (
+      <VStack gap={4} align="stretch">
+        <LoadingSkeleton count={1} />
+        <LoadingSkeleton count={1} />
+      </VStack>
+    )
+  }
+
+  if (publicationError) {
+    return (
+      <Alert.Root status="error">
+        <Alert.Indicator />
+        <Alert.Title>
+          {common.loadFailed()} {publicationError.message}
+        </Alert.Title>
+      </Alert.Root>
+    )
+  }
+
+  if (!publication) {
+    return (
+      <VStack gap={4} align="center" py={8}>
+        <Text color="gray.500">{common.contentNotExists()}</Text>
+      </VStack>
+    )
+  }
+
+  return (
+    <>
+      <VStack gap={4} align="stretch">
+        {/* 发布详情 - 编辑模式或查看模式 */}
+        {isEditMode ? (
+          <PublicationEditForm
+            publication={publication}
+            onSave={handleSaveEdit}
+            onCancel={handleCancelEdit}
+            isLoading={false}
+          />
+        ) : (
+          <PublicationItem
+            publication={publication}
+            isNodeOwner={isNodeOwner}
+            isAuthenticated={authStatus === "AUTHENTICATED"}
+            onSign={handleSignPublication}
+            onDelete={handleDeleteClick}
+            onShowSignature={handleShowSignature}
+            onEdit={handleEdit}
+            showAuthorInfo={false}
+          />
+        )}
+
+        {/* 评论区域 - 只有在允许评论时才显示 */}
+        {settings?.allowComment && (
+          <UnifiedCard.Root>
+            <UnifiedCard.Header>
+              <Text fontSize="xl" fontWeight="semibold">
+                {common.comments()} ({publication?.comment_count || 0})
+              </Text>
+            </UnifiedCard.Header>
+
+            <UnifiedCard.Body>
+              {/* 评论列表 - 放在表单上方 */}
+              <CommentList
+                publicationId={publicationId}
+                onCommentDeleted={() => {
+                  // 刷新评论列表并更新 publication 的评论数
+                  if (typeof commentRefetch === "function") {
+                    commentRefetch()
+                  }
+                  handleCommentCreated()
+                }}
+                localPendingComment={localPendingComment}
+                onRetrySignature={retrySignatureFn}
+                onSetRefetch={setCommentRefetch}
+              />
+
+              {/* 分割线 */}
+              <Separator my={6} />
+
+              {/* 评论表单 */}
+              <CommentForm
+                publicationId={publicationId}
+                onCommentCreated={() => {
+                  // 刷新评论列表并更新 publication 的评论数
+                  if (typeof commentRefetch === "function") {
+                    commentRefetch()
+                  }
+                  handleCommentCreated()
+                }}
+                onPendingCommentChange={(pending, retryFn) => {
+                  setLocalPendingComment(pending)
+                  setRetrySignatureFn(() => retryFn)
+                }}
+              />
+            </UnifiedCard.Body>
+          </UnifiedCard.Root>
+        )}
+      </VStack>
+
+      {/* 删除确认对话框 */}
+      <ConfirmDialog
+        isOpen={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={handleConfirmDelete}
+        title={common.confirmDelete()}
+        message={common.confirmDeleteMessage()}
+        confirmText={common.confirmDeleteText()}
+        cancelText={common.cancel()}
+        confirmColorPalette="red"
+        isLoading={isDeleting}
+      />
+
+      {/* 签名信息对话框 */}
+      <InfoDialog
+        isOpen={signatureDialogOpen}
+        onClose={() => setSignatureDialogOpen(false)}
+        title={common.signatureInfo()}
+        content={signatureInfo}
+        closeText={common.close()}
+        isPreformatted={true}
+      />
+    </>
+  )
+}

--- a/client/app/publications/[id]/page.jsx
+++ b/client/app/publications/[id]/page.jsx
@@ -1,197 +1,35 @@
-"use client"
-import { Alert, Separator, Text, VStack } from "@chakra-ui/react"
-import { useState } from "react"
+import PreloadApolloCache from "../../../components/util/PreloadApolloCache"
 import {
-  CommentForm,
-  CommentList,
-  PublicationEditForm,
-  PublicationItem,
-} from "../../../components/business"
-import {
-  ConfirmDialog,
-  InfoDialog,
-  LoadingSkeleton,
-  UnifiedCard,
-} from "../../../components/ui"
-import { usePage } from "../../../contexts/PageContext"
-import { usePageTitle } from "../../../hooks/usePageTitle"
-import { usePublicationDetail } from "../../../hooks/usePublicationDetail"
-import { useTranslation } from "../../../hooks/useTranslation"
-import { stripMarkdown, truncateText } from "../../../utils/textUtils"
+  executeServerQueries,
+  getRequestApolloClient,
+} from "../../../graphql/index"
+import { FETCH } from "../../../graphql/queries"
+import ClientPage from "./page.client"
 
-export default function PublicationDetailPage() {
-  const { common } = useTranslation()
-  const { settings } = usePage()
-  const [localPendingComment, setLocalPendingComment] = useState(null)
-  const [retrySignatureFn, setRetrySignatureFn] = useState(null)
-  const [commentRefetch, setCommentRefetch] = useState(null)
-  const {
-    publicationId,
-    isEditMode,
-    publication,
-    publicationLoading,
-    publicationError,
-    deleteDialogOpen,
-    signatureDialogOpen,
-    signatureInfo,
-    isDeleting,
-    authStatus,
-    isNodeOwner,
-    handleEdit,
-    handleCancelEdit,
-    handleSaveEdit,
-    handleSignPublication,
-    handleDeleteClick,
-    handleConfirmDelete,
-    handleShowSignature,
-    handleCommentCreated,
-    setDeleteDialogOpen,
-    setSignatureDialogOpen,
-  } = usePublicationDetail()
+export default async function PublicationDetailServerPage({ params }) {
+  const client = getRequestApolloClient()
 
-  // 生成页面标题
-  const getPageTitle = () => {
-    if (!publication) return common.pageTitle.contentDetail()
-
-    let textToTruncate = ""
-    if (publication.content?.type === "FILE") {
-      textToTruncate = publication.description || ""
-    } else {
-      textToTruncate = publication.content?.body || ""
-    }
-
-    if (!textToTruncate) return common.pageTitle.contentDetail()
-
-    const plainText = stripMarkdown(textToTruncate)
-    const truncatedText = truncateText(plainText, 30)
-    return truncatedText
-  }
-
-  // 设置页面标题 - 必须在所有条件渲染之前
-  usePageTitle(getPageTitle())
-
-  if (publicationLoading) {
-    return (
-      <VStack gap={4} align="stretch">
-        <LoadingSkeleton count={1} />
-        <LoadingSkeleton count={1} />
-      </VStack>
-    )
-  }
-
-  if (publicationError) {
-    return (
-      <Alert.Root status="error">
-        <Alert.Indicator />
-        <Alert.Title>
-          {common.loadFailed()} {publicationError.message}
-        </Alert.Title>
-      </Alert.Root>
-    )
-  }
-
-  if (!publication) {
-    return (
-      <VStack gap={4} align="center" py={8}>
-        <Text color="gray.500">{common.contentNotExists()}</Text>
-      </VStack>
-    )
-  }
+  const { data: serverDataMap } = await executeServerQueries(
+    [
+      {
+        queryKey: "FETCH",
+        query: FETCH,
+        variables: {
+          type: "PUBLICATION",
+          id: params.id,
+        },
+      },
+    ],
+    client,
+  )
 
   return (
     <>
-      <VStack gap={4} align="stretch">
-        {/* 发布详情 - 编辑模式或查看模式 */}
-        {isEditMode ? (
-          <PublicationEditForm
-            publication={publication}
-            onSave={handleSaveEdit}
-            onCancel={handleCancelEdit}
-            isLoading={false}
-          />
-        ) : (
-          <PublicationItem
-            publication={publication}
-            isNodeOwner={isNodeOwner}
-            isAuthenticated={authStatus === "AUTHENTICATED"}
-            onSign={handleSignPublication}
-            onDelete={handleDeleteClick}
-            onShowSignature={handleShowSignature}
-            onEdit={handleEdit}
-            showAuthorInfo={false}
-          />
-        )}
-
-        {/* 评论区域 - 只有在允许评论时才显示 */}
-        {settings?.allowComment && (
-          <UnifiedCard.Root>
-            <UnifiedCard.Header>
-              <Text fontSize="xl" fontWeight="semibold">
-                {common.comments()} ({publication?.comment_count || 0})
-              </Text>
-            </UnifiedCard.Header>
-
-            <UnifiedCard.Body>
-              {/* 评论列表 - 放在表单上方 */}
-              <CommentList
-                publicationId={publicationId}
-                onCommentDeleted={() => {
-                  // 刷新评论列表并更新 publication 的评论数
-                  if (typeof commentRefetch === "function") {
-                    commentRefetch()
-                  }
-                  handleCommentCreated()
-                }}
-                localPendingComment={localPendingComment}
-                onRetrySignature={retrySignatureFn}
-                onSetRefetch={setCommentRefetch}
-              />
-
-              {/* 分割线 */}
-              <Separator my={6} />
-
-              {/* 评论表单 */}
-              <CommentForm
-                publicationId={publicationId}
-                onCommentCreated={() => {
-                  // 刷新评论列表并更新 publication 的评论数
-                  if (typeof commentRefetch === "function") {
-                    commentRefetch()
-                  }
-                  handleCommentCreated()
-                }}
-                onPendingCommentChange={(pending, retryFn) => {
-                  setLocalPendingComment(pending)
-                  setRetrySignatureFn(() => retryFn)
-                }}
-              />
-            </UnifiedCard.Body>
-          </UnifiedCard.Root>
-        )}
-      </VStack>
-
-      {/* 删除确认对话框 */}
-      <ConfirmDialog
-        isOpen={deleteDialogOpen}
-        onClose={() => setDeleteDialogOpen(false)}
-        onConfirm={handleConfirmDelete}
-        title={common.confirmDelete()}
-        message={common.confirmDeleteMessage()}
-        confirmText={common.confirmDeleteText()}
-        cancelText={common.cancel()}
-        confirmColorPalette="red"
-        isLoading={isDeleting}
-      />
-
-      {/* 签名信息对话框 */}
-      <InfoDialog
-        isOpen={signatureDialogOpen}
-        onClose={() => setSignatureDialogOpen(false)}
-        title={common.signatureInfo()}
-        content={signatureInfo}
-        closeText={common.close()}
-        isPreformatted={true}
-      />
+      <PreloadApolloCache serverDataMap={serverDataMap} />
+      {(() => {
+        const initialPublication = serverDataMap?.FETCH?.data?.fetch || null
+        return <ClientPage initialPublication={initialPublication} />
+      })()}
     </>
   )
 }

--- a/client/app/publications/page.client.jsx
+++ b/client/app/publications/page.client.jsx
@@ -1,0 +1,63 @@
+"use client"
+import { PublicationForm, PublicationList } from "../../components/business"
+import { useHomePage } from "../../hooks/useHomePage"
+import { usePageTitle } from "../../hooks/usePageTitle"
+import { useTranslation } from "../../hooks/useTranslation"
+
+export default function HomePage({
+  initialPublications = [],
+  initialPageInfo = null,
+  initialTotal = 0,
+}) {
+  const { common } = useTranslation()
+  const {
+    isLoading,
+    formResetTrigger,
+    isNodeOwner,
+    authStatus,
+    profile,
+    handleEdit,
+    handleSetRefetch,
+    handleContentChange,
+    handleFileSelect,
+    handleFileRemove,
+    handleSubmit,
+  } = useHomePage()
+
+  // 设置页面标题
+  usePageTitle(common.pageTitle.home())
+
+  return (
+    <>
+      {/* 发布表单 - 只有节点所有者且已认证才显示 */}
+      {isNodeOwner && authStatus === "AUTHENTICATED" && (
+        <PublicationForm
+          onContentChange={handleContentChange}
+          onSubmit={handleSubmit}
+          isLoading={isLoading}
+          disabled={isLoading}
+          onFileSelect={handleFileSelect}
+          onFileRemove={handleFileRemove}
+          resetTrigger={formResetTrigger}
+        />
+      )}
+
+      {/* 发布列表 */}
+      <PublicationList
+        initialPublications={initialPublications}
+        initialPageInfo={initialPageInfo}
+        initialTotal={initialTotal}
+        nodeAddress={profile?.address}
+        onEdit={handleEdit}
+        onSetRefetch={handleSetRefetch}
+        onPublicationCreated={() => {
+          // 刷新发布列表
+          if (handleSetRefetch) {
+            handleSetRefetch()
+          }
+        }}
+        onPublish={handleSubmit} // 复用现有的发布逻辑
+      />
+    </>
+  )
+}

--- a/client/app/publications/page.jsx
+++ b/client/app/publications/page.jsx
@@ -1,56 +1,49 @@
-"use client"
-import { PublicationForm, PublicationList } from "../../components/business"
-import { useHomePage } from "../../hooks/useHomePage"
-import { usePageTitle } from "../../hooks/usePageTitle"
-import { useTranslation } from "../../hooks/useTranslation"
+import PreloadApolloCache from "../../components/util/PreloadApolloCache"
+import {
+  executeServerQueries,
+  getRequestApolloClient,
+} from "../../graphql/index"
+import { SEARCH_PUBLICATIONS } from "../../graphql/queries"
+import ClientPage from "./page.client"
 
-export default function HomePage() {
-  const { common } = useTranslation()
-  const {
-    isLoading,
-    formResetTrigger,
-    isNodeOwner,
-    authStatus,
-    profile,
-    handleEdit,
-    handleSetRefetch,
-    handleContentChange,
-    handleFileSelect,
-    handleFileRemove,
-    handleSubmit,
-  } = useHomePage()
+export default async function PublicationsServerPage() {
+  const client = getRequestApolloClient()
 
-  // 设置页面标题
-  usePageTitle(common.pageTitle.home())
+  const { data: serverDataMap } = await executeServerQueries(
+    [
+      {
+        queryKey: "SEARCH_PUBLICATIONS",
+        query: SEARCH_PUBLICATIONS,
+        variables: {
+          filterBy: null,
+          orderBy: "-created_at",
+          first: 10,
+        },
+      },
+    ],
+    client,
+  )
 
   return (
     <>
-      {/* 发布表单 - 只有节点所有者且已认证才显示 */}
-      {isNodeOwner && authStatus === "AUTHENTICATED" && (
-        <PublicationForm
-          onContentChange={handleContentChange}
-          onSubmit={handleSubmit}
-          isLoading={isLoading}
-          disabled={isLoading}
-          onFileSelect={handleFileSelect}
-          onFileRemove={handleFileRemove}
-          resetTrigger={formResetTrigger}
-        />
-      )}
+      {/* 将服务器端数据预加载到 Apollo 缓存 */}
+      <PreloadApolloCache serverDataMap={serverDataMap} />
+      {/* 渲染客户端页面 */}
+      {(() => {
+        const search = serverDataMap?.SEARCH_PUBLICATIONS?.data?.search
+        const initialEdges = search?.edges || []
+        const initialPublications = initialEdges.map((e) => e.node)
+        const initialPageInfo = search?.pageInfo || null
+        const initialTotal = search?.total || 0
 
-      {/* 发布列表 */}
-      <PublicationList
-        nodeAddress={profile?.address}
-        onEdit={handleEdit}
-        onSetRefetch={handleSetRefetch}
-        onPublicationCreated={() => {
-          // 刷新发布列表
-          if (handleSetRefetch) {
-            handleSetRefetch()
-          }
-        }}
-        onPublish={handleSubmit} // 复用现有的发布逻辑
-      />
+        return (
+          <ClientPage
+            initialPublications={initialPublications}
+            initialPageInfo={initialPageInfo}
+            initialTotal={initialTotal}
+          />
+        )
+      })()}
     </>
   )
 }

--- a/client/components/business/Comment/List.jsx
+++ b/client/components/business/Comment/List.jsx
@@ -1,12 +1,11 @@
 "use client"
 
 import { useQuery } from "@apollo/client/react"
-import { Alert, Button, HStack, Text, VStack } from "@chakra-ui/react"
+import { Alert, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react"
 import { useEffect, useState } from "react"
 import { LuEllipsis } from "react-icons/lu"
 import { SEARCH_COMMENTS } from "../../../graphql/queries"
 import { useTranslation } from "../../../hooks/useTranslation"
-import { LoadingSkeleton } from "../../ui"
 import { toaster } from "../../ui/toaster"
 import { CommentItem } from "./Item"
 
@@ -98,7 +97,12 @@ const CommentList = ({
   }
 
   if (loading && !data) {
-    return <LoadingSkeleton count={2} />
+    return (
+      <VStack colorPalette="orange">
+        <Spinner color="colorPalette.600" />
+        <Text color="colorPalette.600">Loading...</Text>
+      </VStack>
+    )
   }
 
   if (error) {

--- a/client/components/business/Publication/Item.jsx
+++ b/client/components/business/Publication/Item.jsx
@@ -419,6 +419,7 @@ export const PublicationItem = ({
                 title={formatTime(publication.created_at, currentLanguage)}
                 color="gray.500"
                 fontSize="sm"
+                suppressHydrationWarning
               >
                 {formatRelativeTime(publication.created_at, currentLanguage)}
               </Link>

--- a/client/components/layout/Page.jsx
+++ b/client/components/layout/Page.jsx
@@ -32,9 +32,7 @@ export function Page({ children, runtimeConfig, serverDataMap, serverErrors }) {
                     <Header />
                     <main className="content-area">
                       <Container maxW="6xl" py={6}>
-                        <Suspense fallback={<div>Loading...</div>}>
-                          {children}
-                        </Suspense>
+                        <Suspense fallback={null}>{children}</Suspense>
                       </Container>
                     </main>
                     <Footer />

--- a/client/components/util/PreloadApolloCache.jsx
+++ b/client/components/util/PreloadApolloCache.jsx
@@ -1,0 +1,7 @@
+"use client"
+import { usePagePreload } from "../client/apollo-provider"
+
+export default function PreloadApolloCache({ serverDataMap }) {
+  usePagePreload(serverDataMap)
+  return null
+}

--- a/client/graphql/queries.js
+++ b/client/graphql/queries.js
@@ -172,6 +172,54 @@ export const SEARCH_NODES = gql`
   }
 `
 
+// 合并 connections 页面所需的两个查询，避免 queryKey 冲突并一次性预加载缓存
+export const CONNECTIONS_PAGE_DATA = gql`
+  query ConnectionsPageData($orderBy: String, $followersFirst: Int, $followingFirst: Int) {
+    followers: search(
+      type: NODE
+      filterBy: { type: "followers" }
+      orderBy: $orderBy
+      first: $followersFirst
+    ) {
+      total
+      edges {
+        cursor
+        node {
+          ... on Node {
+            ${segments.node}
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+      }
+    }
+    following: search(
+      type: NODE
+      filterBy: { type: "following" }
+      orderBy: $orderBy
+      first: $followingFirst
+    ) {
+      total
+      edges {
+        cursor
+        node {
+          ... on Node {
+            ${segments.node}
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+`
+
 // 单独的查询 - 现在分别在服务器端和客户端使用
 export const IS_FOLLOWER = gql`
   query IsFollower($address: String!) {

--- a/client/hooks/useConnection.js
+++ b/client/hooks/useConnection.js
@@ -118,7 +118,6 @@ export function useConnection() {
         ],
         awaitRefetchQueries: true,
       })
-
       toaster.create({
         description: connection.followSuccess(url),
         type: "success",

--- a/client/hooks/useHomePage.js
+++ b/client/hooks/useHomePage.js
@@ -102,9 +102,6 @@ export function useHomePage() {
         // 使用fetch直接发送multipart请求
         const response = await fetch("/api/graphql", {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("authToken")}`,
-          },
           body: formDataToSend,
         })
 

--- a/client/hooks/useProfileForm.js
+++ b/client/hooks/useProfileForm.js
@@ -94,9 +94,6 @@ export function useProfileForm() {
 
         const response = await fetch("/api/graphql", {
           method: "POST",
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("authToken")}`,
-          },
           body: formData,
         })
 

--- a/client/hooks/usePublicationDetail.js
+++ b/client/hooks/usePublicationDetail.js
@@ -13,7 +13,7 @@ import { statementOfSourceTypedData } from "../utils/eip712"
 import { useTranslation } from "./useTranslation"
 import { useWallet } from "./useWallet"
 
-export function usePublicationDetail() {
+export function usePublicationDetail(options = {}) {
   const params = useParams()
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -39,7 +39,7 @@ export function usePublicationDetail() {
   // 获取Publication详情
   const {
     data: publicationData,
-    loading: publicationLoading,
+    loading: queryLoading,
     error: publicationError,
     refetch: refetchPublication,
   } = useQuery(FETCH, {
@@ -47,10 +47,16 @@ export function usePublicationDetail() {
       type: "PUBLICATION",
       id: publicationId,
     },
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: options.initialPublication
+      ? "cache-first"
+      : "cache-and-network",
+    nextFetchPolicy: "cache-and-network",
   })
 
-  const publication = publicationData?.fetch
+  const publication =
+    publicationData?.fetch || options.initialPublication || null
+  const publicationLoading =
+    queryLoading && !publicationData && !options.initialPublication
 
   // 处理编辑
   const handleEdit = (publication) => {
@@ -72,7 +78,6 @@ export function usePublicationDetail() {
         id: id,
         body: content, // 直接传递 body 内容
       }
-      console.log(publication, "===================")
       if (publication.content.type === "FILE") {
         delete input.body
         input.description = content

--- a/client/middleware.js
+++ b/client/middleware.js
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+
+// 将 HttpOnly cookie 中的 authToken 注入为 Authorization 头
+export function middleware(request) {
+  const token = request.cookies.get("authToken")?.value
+
+  if (!token) {
+    return NextResponse.next()
+  }
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set("authorization", `Bearer ${token}`)
+
+  // 继续后续处理（包括重写到外部 API）时带上新的请求头
+  return NextResponse.next({ request: { headers: requestHeaders } })
+}
+
+// 仅匹配需要代理到后端的路径，以及 /feed（其可读取 Authorization）
+export const config = {
+  matcher: ["/api/:path*", "/ewp/:path*", "/feed"],
+}


### PR DESCRIPTION
This commit introduces two major architectural improvements: Server-Side Rendering (SSR) for key pages and a more secure authentication mechanism using HttpOnly cookies.

### Server-Side Rendering (SSR)

- **Key Pages:** The Home (publications), Publication Detail, and Connections pages are now server-rendered to improve initial load performance and SEO.
- **Implementation:** Pages are split into Server Components for initial data fetching and Client Components for interactivity.
- **Cache Hydration:** Server-fetched data is used to preload the client-side Apollo cache, ensuring a smooth transition to a fully interactive page without re-fetching data.

### Authentication Refactor

- **From "localStorage" to "HttpOnly" Cookies:** The JWT "authToken" is no longer stored in "localStorage". It is now stored in a server-set "HttpOnly" cookie, which is not accessible to client-side JavaScript, mitigating XSS risks.
- **New Middleware:** A new "middleware.js" is introduced to read the token from the cookie and inject it into the "Authorization" header for all API requests.
- **Benefits:** This change significantly improves security and enables authenticated requests to be made during the server-side rendering process.

Closes #7 