### PR TITLE
fix(client): Fix publication form state and submission logic

### DIFF
--- a/client/components/ui/FileUploadZone.jsx
+++ b/client/components/ui/FileUploadZone.jsx
@@ -99,17 +99,26 @@ const UploadOrPreview = ({ maxSize, onFileRemove }) => {
 }
 
 export function FileUploadZone({
+  selectedFile,
   onFileSelect,
   onRemoveFile,
   maxSize = 100 * 1024 * 1024,
   maxFiles = 1,
 }) {
+  const files = selectedFile ? [selectedFile] : []
   return (
     <FileUpload.Root
+      acceptedFiles={files}
+      onFileChange={(e) => {
+        if (e.acceptedFiles.length > 0) {
+          onFileSelect({ files: e.acceptedFiles })
+        } else {
+          onRemoveFile({ preventDefault: () => {} })
+        }
+      }}
       alignItems="stretch"
       maxFiles={maxFiles}
       maxFileSize={maxSize}
-      onFileAccept={onFileSelect}
     >
       <FileUpload.HiddenInput />
       <FileUpload.Dropzone

--- a/client/hooks/usePublicationForm.js
+++ b/client/hooks/usePublicationForm.js
@@ -198,7 +198,7 @@ export function usePublicationForm({
     return {
       mode,
       content: mode === "post" ? content : fileDescription,
-      file: selectedFile,
+      file: mode === "file" ? selectedFile : null,
     }
   }
 


### PR DESCRIPTION
- Fixes a bug where switching between post and file mode could lead to an incorrect submission payload.
- Makes the file upload component controlled to prevent state loss when switching tabs.
- Corrects the callback signature for file selection to prevent runtime errors.

Closes #35