### PR TITLE
chore(docker): Clean up entrypoint and improve .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,11 @@
 # Node
 node_modules
 
+# env
+.env.local
+.env.production
+.env.development
+
 # Logs and data
 logs
 data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,24 +6,16 @@ set -e
 # Create a symlink for the .env file to the persistent data volume.
 # This ensures user configuration is not lost when the container is removed.
 # The -f flag ensures that if the link already exists, it is replaced.
-ln -sf /app/data/.env /app/.env
 
 # Check the first argument to decide what to do.
 case "$1" in
-  install)
-    echo "Running interactive installation..."
-    # Remove 'install' from the arguments list
-    shift
-    # Run the installation script, passing any extra args like --force or --non-interactive
-    exec node commands/install.mjs "$@"
-    ;;
   start)
     echo "Starting application..."
     # Run the main application
     exec npm run start
     ;;
   *)
-    # If the command is not 'install' or 'start', execute it directly.
+    # If the command is not 'start', execute it directly.
     # This allows running arbitrary commands like `docker run ... sh` for debugging.
     exec "$@"
     ;;


### PR DESCRIPTION
This PR contains follow-up fixes for the Docker environment after the recent installation refactor.

- Removes the obsolete `install` command and `.env` symlinking from the entrypoint script.
- Adds `.env.*` files to `.dockerignore` to prevent them from being included in the build context.