### PR TITLE
fix(ui): Correct state handling in selectors and clean up Page component

### DIFF
--- a/client/components/layout/Page.jsx
+++ b/client/components/layout/Page.jsx
@@ -31,14 +31,8 @@ export function Page({ children }) {
   // 创建 refetchPageData 函数
   const refetchPageData = useCallback(async () => {
     if (isClient) {
-      try {
-        const result = await refetch()
-        console.log("PageContext refetch successful:", result)
-        return result
-      } catch (refetchError) {
-        console.error("PageContext refetch failed:", refetchError)
-        throw refetchError
-      }
+      const result = await refetch()
+      return result
     }
   }, [refetch, isClient])
 

--- a/client/components/ui/LanguageSelect.jsx
+++ b/client/components/ui/LanguageSelect.jsx
@@ -21,7 +21,7 @@ export function LanguageSelect({ value, onChange }) {
       </Text>
       <Select.Root
         collection={languageCollection}
-        defaultValue={[value]}
+        value={[value]}
         onValueChange={(details) => onChange(details.value[0])}
       >
         <Select.HiddenSelect />

--- a/client/components/ui/ThemeSelector.jsx
+++ b/client/components/ui/ThemeSelector.jsx
@@ -23,7 +23,7 @@ export function ThemeSelector({ value, onChange }) {
       </Text>
       <Select.Root
         collection={themeCollection}
-        defaultValue={[value]}
+        value={[value]}
         onValueChange={(details) => onChange(details.value[0])}
       >
         <Select.HiddenSelect />


### PR DESCRIPTION
This PR fixes two issues:

1.  Updates `LanguageSelect` and `ThemeSelector` to use the `value` prop instead of `defaultValue`. This turns them into proper controlled components and fixes a bug where their displayed value would not update correctly.
2.  Removes a redundant `try...catch` block from the `Page` component for simplification.