### PR TITLE
feat(visitor): Add size limit to online visitors list

### DIFF
--- a/client/components/features/visitor/OnlineVisitorsButton.jsx
+++ b/client/components/features/visitor/OnlineVisitorsButton.jsx
@@ -35,17 +35,10 @@ export function OnlineVisitorsButton() {
   return (
     <Popover.Root placement="top">
       <Popover.Trigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          _hover={{
-            bgColor: "gray.200",
-            _dark: { bgColor: "gray.600" },
-          }}
-        >
-          <HStack gap={2}>
+        <Button variant="plain" color="fg.muted" size="sm" px={0}>
+          <HStack gap={1}>
             <LuUsers size={16} />
-            <Text fontSize="sm" color="gray.500" _dark={{ color: "gray.400" }}>
+            <Text fontSize="sm">
               {t("visitor.onlineCount", { count: onlineCount })}
             </Text>
             <Circle

--- a/client/components/layout/Footer.jsx
+++ b/client/components/layout/Footer.jsx
@@ -91,27 +91,16 @@ export const Footer = () => {
             </Link>
 
             {/* 右侧：在线访客 + 运行状态 */}
-            <HStack gap={1}>
+            <HStack gap={3}>
               {/* 在线访客按钮 */}
               <OnlineVisitorsButton />
 
               {/* 运行状态按钮 */}
               <Popover.Root placement="top">
                 <Popover.Trigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    _hover={{
-                      bgColor: "gray.200",
-                      _dark: { bgColor: "gray.600" },
-                    }}
-                  >
-                    <HStack gap={2}>
-                      <Text
-                        fontSize="sm"
-                        color="gray.500"
-                        _dark={{ color: "gray.400" }}
-                      >
+                  <Button variant="plain" color="fg.muted" size="sm" px={0}>
+                    <HStack gap={1}>
+                      <Text fontSize="sm">
                         {t("common.onlineDays", { days: runningDays })}
                       </Text>
                       <Box


### PR DESCRIPTION
### Description

This PR addresses Issue #74 by introducing a size limit to the in-memory online visitors list to prevent potential memory exhaustion attacks.

### Key Changes

- Enforces a hard limit of 1,000 concurrent online visitors (MAX_VISITORS).
- Implements a First-In, First-Out (FIFO) eviction strategy when the visitor limit is reached.
- Updates the `POST /api/visitors` endpoint with the new eviction logic.
- Updates the `GET /api/visitors` endpoint to return the `limit` and hide internal fields.
- Improves Ethereum address validation by using the `validator` library.
- Includes comprehensive tests for the new FIFO eviction logic.
- Contains minor UI adjustments to the visitor button style.

Closes #74