### PR TITLE
feat(client): Implement drawer for comments on publication list

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/client/components/features/comment/List.jsx
+++ b/client/components/features/comment/List.jsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useSuspenseQuery } from "@apollo/client/react"
+import { useQuery, useSuspenseQuery } from "@apollo/client/react"
 import { Alert, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react"
 import { useEffect, useState } from "react"
 import { LuEllipsis } from "react-icons/lu"
@@ -15,13 +15,15 @@ export const CommentList = ({
   localPendingComment,
   onRetrySignature,
   onSetRefetch,
+  suspense = true,
 }) => {
   const [hasMore, setHasMore] = useState(false)
   const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
   const { t } = useIntl()
 
+  const useQueryHook = suspense ? useSuspenseQuery : useQuery
   // 获取评论列表 - 使用 Apollo Client
-  const { data, loading, error, fetchMore, refetch } = useSuspenseQuery(
+  const { data, loading, error, fetchMore, refetch } = useQueryHook(
     SEARCH_COMMENTS,
     {
       variables: {

--- a/client/components/features/publication/ItemPage.jsx
+++ b/client/components/features/publication/ItemPage.jsx
@@ -110,6 +110,7 @@ export function PublicationItemPage({ variables }) {
             onShowSignature={handleShowSignature}
             onEdit={handleEdit}
             showAuthorInfo={false}
+            showCommentIcon={false}
             onPublish={handlePublish}
           />
         )}

--- a/client/hooks/form/useCommentForm.js
+++ b/client/hooks/form/useCommentForm.js
@@ -275,7 +275,7 @@ export function useCommentForm(
 
       if (!skipToast) {
         toaster.create({
-          description: t("comment.commentSubmitSuccess"),
+          description: t("comment.commentSubmitSuccessEthereum"),
           type: "success",
         })
       }

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -213,6 +213,7 @@
     "required": "This field is required",
     "commentSubmitSuccess": "Comment submitted successfully! Please check your email and click the verification link. The comment will be displayed after verification.",
     "commentSubmitSuccessShort": "Comment submitted successfully",
+    "commentSubmitSuccessEthereum": "Comment successfully",
     "commentDeleteSuccess": "Comment deleted successfully",
     "commentVerifySuccess": "Comment verification successful! Your comment is now displayed.",
     "commentVerificationSuccess": "Comment verification successful!",

--- a/client/messages/zh.json
+++ b/client/messages/zh.json
@@ -213,6 +213,7 @@
     "required": "此字段为必填项",
     "commentSubmitSuccess": "评论提交成功!请检查您的邮箱并点击验证链接,验证后评论才会显示。",
     "commentSubmitSuccessShort": "评论提交成功",
+    "commentSubmitSuccessEthereum": "评论发表成功",
     "commentDeleteSuccess": "评论删除成功",
     "commentVerifySuccess": "评论验证成功!您的评论现在已显示。",
     "commentVerificationSuccess": "评论验证成功!",


### PR DESCRIPTION
Closes #91

This PR enhances the user experience by allowing users to view and add comments directly from the publication list without navigating to the detail page.

Key changes include:
- Replaced the comment icons navigation behavior with a Drawer that opens from the bottom of the screen.
- The Drawer contains the comment list and a form for submitting new comments.
- The comment count on the publication item updates in real-time when a comment is added or deleted.
- Added a suspense prop to the CommentList component to allow it to be used within the non-suspending Drawer.
- Updated i18n keys for more specific success messages.