### PR TITLE
fix(client): correct pull-to-refresh behavior and skeleton overflow

### DIFF
--- a/client/components/features/comment/List.jsx
+++ b/client/components/features/comment/List.jsx
@@ -2,182 +2,187 @@
 
 import { useQuery, useSuspenseQuery } from "@apollo/client/react"
 import { Alert, Button, HStack, Spinner, Text, VStack } from "@chakra-ui/react"
-import { useEffect, useState } from "react"
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react"
 import { LuEllipsis } from "react-icons/lu"
 import { useIntl } from "@/hooks/utils"
 import { SEARCH_COMMENTS } from "@/lib/apollo"
 import { toaster } from "../../ui/toaster"
 import { CommentItem } from "./Item"
 
-export const CommentList = ({
-  publicationId,
-  onCommentDeleted,
-  localPendingComment,
-  onRetrySignature,
-  onSetRefetch,
-  suspense = true,
-}) => {
-  const [hasMore, setHasMore] = useState(false)
-  const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
-  const { t } = useIntl()
-
-  const useQueryHook = suspense ? useSuspenseQuery : useQuery
-  // 获取评论列表 - 使用 Apollo Client
-  const { data, loading, error, fetchMore, refetch } = useQueryHook(
-    SEARCH_COMMENTS,
+export const CommentList = forwardRef(
+  (
     {
-      variables: {
-        filterBy: { publication_id: publicationId },
-        orderBy: "-created_at",
-        first: 10,
-      },
-      notifyOnNetworkStatusChange: true,
-      fetchPolicy: "cache-and-network", // 确保数据一致性
+      publicationId,
+      onCommentDeleted,
+      localPendingComment,
+      onRetrySignature,
+      suspense = true,
     },
-  )
+    ref,
+  ) => {
+    const [hasMore, setHasMore] = useState(false)
+    const [hasAttemptedLoadMore, setHasAttemptedLoadMore] = useState(false)
+    const { t } = useIntl()
 
-  // 更新 hasMore 状态
-  useEffect(() => {
-    if (data?.search?.pageInfo) {
-      setHasMore(data.search.pageInfo.hasNextPage)
-    }
-  }, [data])
-
-  // 将 refetch 暴露给父组件，便于外部触发刷新
-  useEffect(() => {
-    if (onSetRefetch && refetch) {
-      // 通过函数式更新避免 React 将函数视为 updater 并调用它
-      onSetRefetch(() => refetch)
-    }
-  }, [onSetRefetch, refetch])
-
-  // 处理评论删除后的回调
-  const handleCommentDeleted = () => {
-    // 重新获取评论列表以更新缓存
-    refetch()
-    // 通知父组件刷新 publication 数据
-    if (onCommentDeleted) {
-      onCommentDeleted()
-    }
-  }
-
-  // Load more comments - using Apollo Client's fetchMore
-  const loadMore = async (event) => {
-    if (event) {
-      event.preventDefault()
-      event.stopPropagation()
-    }
-
-    if (!hasMore || loading) return
-
-    try {
-      setHasAttemptedLoadMore(true)
-      await fetchMore({
+    const useQueryHook = suspense ? useSuspenseQuery : useQuery
+    // 获取评论列表 - 使用 Apollo Client
+    const { data, loading, error, fetchMore, refetch } = useQueryHook(
+      SEARCH_COMMENTS,
+      {
         variables: {
-          after: data?.search?.pageInfo?.endCursor,
-          // 保持与初次查询一致的排序
+          filterBy: { publication_id: publicationId },
           orderBy: "-created_at",
+          first: 10,
         },
-        updateQuery: (prev, { fetchMoreResult }) => {
-          if (!fetchMoreResult) return prev
+        notifyOnNetworkStatusChange: true,
+        fetchPolicy: "cache-and-network", // 确保数据一致性
+      },
+    )
 
-          return {
-            search: {
-              ...fetchMoreResult.search,
-              edges: [...prev.search.edges, ...fetchMoreResult.search.edges],
-            },
-          }
-        },
-      })
-    } catch (error) {
-      console.error("Failed to load more comments:", error)
-      toaster.create({
-        description: t("common.loadMoreFailed"),
-        type: "error",
-      })
+    // Expose refetch method to parent via ref
+    useImperativeHandle(
+      ref,
+      () => ({
+        refetch,
+      }),
+      [refetch],
+    )
+
+    // 更新 hasMore 状态
+    useEffect(() => {
+      if (data?.search?.pageInfo) {
+        setHasMore(data.search.pageInfo.hasNextPage)
+      }
+    }, [data])
+
+    // 处理评论删除后的回调
+    const handleCommentDeleted = () => {
+      // 重新获取评论列表以更新缓存
+      refetch()
+      // 通知父组件刷新 publication 数据
+      if (onCommentDeleted) {
+        onCommentDeleted()
+      }
     }
-  }
 
-  if (loading && !data) {
+    // Load more comments - using Apollo Client's fetchMore
+    const loadMore = async (event) => {
+      if (event) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+
+      if (!hasMore || loading) return
+
+      try {
+        setHasAttemptedLoadMore(true)
+        await fetchMore({
+          variables: {
+            after: data?.search?.pageInfo?.endCursor,
+            // 保持与初次查询一致的排序
+            orderBy: "-created_at",
+          },
+          updateQuery: (prev, { fetchMoreResult }) => {
+            if (!fetchMoreResult) return prev
+
+            return {
+              search: {
+                ...fetchMoreResult.search,
+                edges: [...prev.search.edges, ...fetchMoreResult.search.edges],
+              },
+            }
+          },
+        })
+      } catch (error) {
+        console.error("Failed to load more comments:", error)
+        toaster.create({
+          description: t("common.loadMoreFailed"),
+          type: "error",
+        })
+      }
+    }
+
+    if (loading && !data) {
+      return (
+        <VStack colorPalette="orange">
+          <Spinner color="colorPalette.600" />
+          <Text color="colorPalette.600">Loading...</Text>
+        </VStack>
+      )
+    }
+
+    if (error) {
+      return (
+        <Alert.Root status="error" py={8}>
+          <Alert.Indicator />
+          <Alert.Content>
+            <Alert.Title>{t("common.loadFailed")}</Alert.Title>
+            <Alert.Description>{error.message}</Alert.Description>
+          </Alert.Content>
+        </Alert.Root>
+      )
+    }
+
+    const comments = data?.search?.edges?.map((edge) => edge.node) || []
+
     return (
-      <VStack colorPalette="orange">
-        <Spinner color="colorPalette.600" />
-        <Text color="colorPalette.600">Loading...</Text>
+      <VStack gap={4} align="stretch">
+        {/* 本地待确认评论置顶显示 */}
+        {localPendingComment && (
+          <CommentItem
+            key={`local-pending-${localPendingComment.id}`}
+            comment={{
+              id: localPendingComment.id,
+              body: localPendingComment.body,
+              status: "PENDING",
+              auth_type: "ETHEREUM",
+              author_name: localPendingComment.authorName,
+              author_id: localPendingComment.authorId,
+              created_at: localPendingComment.createdAt,
+            }}
+            onCommentDeleted={handleCommentDeleted}
+            isLocalPending={true}
+            onRetrySignature={onRetrySignature}
+          />
+        )}
+
+        {comments.map((comment, index) => (
+          <CommentItem
+            key={`${comment.id}-${index}`}
+            comment={comment}
+            onCommentDeleted={handleCommentDeleted}
+          />
+        ))}
+
+        {hasMore && (
+          <HStack justify="center" py={1}>
+            <Button
+              onClick={loadMore}
+              loading={loading}
+              variant="ghost"
+              size="sm"
+              colorPalette="orange"
+              type="button"
+              tabIndex={-1}
+              onFocus={(e) => e.target.blur()}
+            >
+              <LuEllipsis />
+            </Button>
+          </HStack>
+        )}
+
+        {!hasMore && comments.length > 0 && hasAttemptedLoadMore && (
+          <Text textAlign="center" color="gray.500" py={4}>
+            {t("common.noMore")}
+          </Text>
+        )}
+
+        {comments.length === 0 && !loading && !localPendingComment && (
+          <Text textAlign="center" color="gray.500" py={8}>
+            {t("common.noComments")}
+          </Text>
+        )}
       </VStack>
     )
-  }
-
-  if (error) {
-    return (
-      <Alert.Root status="error" py={8}>
-        <Alert.Indicator />
-        <Alert.Content>
-          <Alert.Title>{t("common.loadFailed")}</Alert.Title>
-          <Alert.Description>{error.message}</Alert.Description>
-        </Alert.Content>
-      </Alert.Root>
-    )
-  }
-
-  const comments = data?.search?.edges?.map((edge) => edge.node) || []
-
-  return (
-    <VStack gap={4} align="stretch">
-      {/* 本地待确认评论置顶显示 */}
-      {localPendingComment && (
-        <CommentItem
-          key={`local-pending-${localPendingComment.id}`}
-          comment={{
-            id: localPendingComment.id,
-            body: localPendingComment.body,
-            status: "PENDING",
-            auth_type: "ETHEREUM",
-            author_name: localPendingComment.authorName,
-            author_id: localPendingComment.authorId,
-            created_at: localPendingComment.createdAt,
-          }}
-          onCommentDeleted={handleCommentDeleted}
-          isLocalPending={true}
-          onRetrySignature={onRetrySignature}
-        />
-      )}
-
-      {comments.map((comment, index) => (
-        <CommentItem
-          key={`${comment.id}-${index}`}
-          comment={comment}
-          onCommentDeleted={handleCommentDeleted}
-        />
-      ))}
-
-      {hasMore && (
-        <HStack justify="center" py={1}>
-          <Button
-            onClick={loadMore}
-            loading={loading}
-            variant="ghost"
-            size="sm"
-            colorPalette="orange"
-            type="button"
-            tabIndex={-1}
-            onFocus={(e) => e.target.blur()}
-          >
-            <LuEllipsis />
-          </Button>
-        </HStack>
-      )}
-
-      {!hasMore && comments.length > 0 && hasAttemptedLoadMore && (
-        <Text textAlign="center" color="gray.500" py={4}>
-          {t("common.noMore")}
-        </Text>
-      )}
-
-      {comments.length === 0 && !loading && !localPendingComment && (
-        <Text textAlign="center" color="gray.500" py={8}>
-          {t("common.noComments")}
-        </Text>
-      )}
-    </VStack>
-  )
-}
+  },
+)

--- a/client/components/features/connection/Page.jsx
+++ b/client/components/features/connection/Page.jsx
@@ -1,9 +1,11 @@
 "use client"
+import { useApolloClient } from "@apollo/client/react"
 import { VStack } from "@chakra-ui/react"
 import { useRef } from "react"
 import { FollowersList, FollowingList } from "@/components/features/connection"
 import { PullToRefresh, toaster } from "@/components/ui"
 import { useIntl, usePageTitle, usePullToRefresh } from "@/hooks/utils"
+import { SEARCH_NODES } from "@/lib/apollo"
 
 /**
  * Connections page component
@@ -12,24 +14,16 @@ import { useIntl, usePageTitle, usePullToRefresh } from "@/hooks/utils"
 export function ConnectionPage() {
   const { t } = useIntl()
   const contentTriggerRef = useRef(null)
-  const followersRef = useRef(null)
-  const followingRef = useRef(null)
+  const client = useApolloClient()
 
   usePageTitle(t("common.pageTitle.connections"))
 
   // Handle refresh for both lists
   const handleRefresh = async () => {
-    // Wait for all refetch operations to complete
     try {
-      // Refetch followers if available
-      if (followersRef.current?.refetch) {
-        await followersRef.current.refetch()
-      }
-
-      // Refetch following if available
-      if (followingRef.current?.refetch) {
-        await followingRef.current.refetch()
-      }
+      await client.refetchQueries({
+        include: [SEARCH_NODES],
+      })
       toaster.create({
         description: t("common.refreshSuccess"),
         type: "success",
@@ -51,7 +45,6 @@ export function ConnectionPage() {
 
   return (
     <>
-      {/* Pull to refresh indicator */}
       <PullToRefresh
         isRefreshing={isRefreshing}
         pullPosition={pullPosition}
@@ -60,8 +53,8 @@ export function ConnectionPage() {
 
       {/* Attach ref to the main content wrapper */}
       <VStack ref={contentTriggerRef} spacing={6} align="stretch">
-        <FollowersList ref={followersRef} />
-        <FollowingList ref={followingRef} />
+        <FollowersList />
+        <FollowingList />
       </VStack>
     </>
   )

--- a/client/components/features/publication/Item.jsx
+++ b/client/components/features/publication/Item.jsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react"
 import { useCopyToClipboard } from "@uidotdev/usehooks"
 import formatFileSize from "pretty-bytes"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { FiEdit3, FiMessageCircle, FiTrash2 } from "react-icons/fi"
 import { LuQuote, LuSend } from "react-icons/lu"
 import { CommentForm, CommentList } from "@/components"
@@ -48,6 +48,7 @@ export function PublicationItem({
 }) {
   const [isSignatureDialogOpen, setIsSignatureDialogOpen] = useState(false)
   const [isQuoteDialogOpen, setIsQuoteDialogOpen] = useState(false)
+  const commentsRef = useRef(null)
   const [isPublishing, setIsPublishing] = useState(false)
   const [_copied, copyToClipboard] = useCopyToClipboard()
   const { t, formatDate, formatRelativeTime } = useIntl()
@@ -57,7 +58,6 @@ export function PublicationItem({
   const [commentCount, setCommentCount] = useState(
     publication.comment_count || 0,
   )
-  const [commentRefetch, setCommentRefetch] = useState(null)
   const [localPendingComment, setLocalPendingComment] = useState(null)
 
   // 生成引用文本
@@ -215,21 +215,18 @@ export function PublicationItem({
   const shouldShowComments = isOwnContent && showCommentIcon
 
   // 处理评论创建成功
-  const handleCommentCreated = () => {
+  const handleCommentCreated = async () => {
     // 刷新评论列表
-    if (commentRefetch) {
-      commentRefetch()
-    }
+    await commentsRef?.current?.refetch()
+
     // 更新评论数量
     setCommentCount((prev) => prev + 1)
   }
 
   // 处理评论删除成功
-  const handleCommentDeleted = () => {
+  const handleCommentDeleted = async () => {
     // 刷新评论列表
-    if (commentRefetch) {
-      commentRefetch()
-    }
+    await commentsRef?.current?.refetch()
     // 更新评论数量
     setCommentCount((prev) => Math.max(0, prev - 1))
   }
@@ -490,11 +487,11 @@ export function PublicationItem({
                 />
                 <Separator my={5} />
                 <CommentList
+                  ref={commentsRef}
                   publicationId={publication.id}
                   onCommentDeleted={handleCommentDeleted}
                   localPendingComment={localPendingComment}
                   onRetrySignature={localPendingComment?.retryFn || undefined}
-                  onSetRefetch={setCommentRefetch}
                   suspense={false}
                 />
               </Drawer.Body>

--- a/client/components/ui/Skeletons.jsx
+++ b/client/components/ui/Skeletons.jsx
@@ -94,7 +94,8 @@ export function Connections() {
             <SkeletonCircle size="12" />
             <Stack flex="1">
               <Skeleton height="5" width="128px" />
-              <Skeleton height="5" width="300px" />
+              {/* **【修复】**：使用相对宽度防止溢出 */}
+              <Skeleton height="5" width="90%" />
             </Stack>
           </HStack>
         </UnifiedCard.Body>
@@ -111,7 +112,8 @@ export function Connections() {
             <SkeletonCircle size="12" />
             <Stack flex="1">
               <Skeleton height="5" width="128px" />
-              <Skeleton height="5" width="300px" />
+              {/* **【修复】**：使用相对宽度防止溢出 */}
+              <Skeleton height="5" width="90%" />
             </Stack>
           </HStack>
         </UnifiedCard.Body>


### PR DESCRIPTION
The primary fix for the pull-to-refresh bug involves replacing component-level refetch() calls with client.refetchQueries(). The original refetch() was triggering a parent Suspense boundary, causing the component to unmount and the refresh indicator to disappear prematurely. client.refetchQueries updates the Apollo cache without triggering this Suspense fallback, thus keeping the component mounted and the indicator visible during the refresh.

The skeleton loader on the connections page has also been fixed to prevent horizontal overflow by using a relative width instead of a fixed one. This change also includes refactoring several components to adopt this new, more stable refresh pattern.

Closes #136