### PR TITLE
feat(client): Implement keyword highlighting with HTML <mark> tag

### DIFF
--- a/client/components/features/publication/Item.jsx
+++ b/client/components/features/publication/Item.jsx
@@ -237,29 +237,6 @@ export function PublicationItem({
     setLocalPendingComment(comment ? { ...comment, retryFn } : null)
   }
 
-  // 渲染内容
-  const renderContent = () => {
-    const { content } = publication
-
-    if (content.type === "POST") {
-      return (
-        <BodyRenderer
-          content={content.body}
-          keyword={keyword}
-          type="markdown"
-        />
-      )
-    } else if (content.type === "FILE") {
-      return publication.description ? (
-        <BodyRenderer
-          content={publication.description}
-          keyword={keyword}
-          type="text"
-        />
-      ) : null
-    }
-  }
-
   return (
     <>
       <UnifiedCard.Root
@@ -303,8 +280,14 @@ export function PublicationItem({
               />
             )}
 
-            {/* 内容 */}
-            {renderContent()}
+            <BodyRenderer
+              content={
+                publication.content.type === "POST"
+                  ? publication.content.body
+                  : publication.description
+              }
+              keyword={keyword}
+            />
 
             {/* 底部信息栏 */}
             <HStack

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,8 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-html": "^16.0.1",
@@ -11654,6 +11656,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-sanitize": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
@@ -11717,6 +11744,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5/node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/hast-util-to-text": {
@@ -18256,6 +18312,35 @@
         "katex": "^0.16.0",
         "unist-util-visit-parents": "^6.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-html": "^16.0.1",


### PR DESCRIPTION
This commit refactors the keyword highlighting functionality in search results
to use the native HTML <mark> tag instead of Chakra UI's Highlight component.
The previous implementation caused issues with Markdown rendering, leading to
an inconsistent user experience.

Changes include:
- Removed Chakra UI's Highlight component usage from `BodyRenderer`.
- Introduced a `highlightKeyword` utility function to wrap keywords with <mark> tags.
- Configured `ReactMarkdown` in `BodyRenderer` to correctly parse and render <mark> tags
  by adding `rehype-raw` and `rehype-sanitize` plugins.
- Updated `PublicationItem` to directly use `BodyRenderer` for content rendering,
  simplifying the logic.
- Added CSS styling for the <mark> tag to ensure visual consistency.
- Updated `package.json` and `package-lock.json` to include new dependencies.

This change ensures that Markdown content is rendered correctly while
still providing clear keyword highlighting, improving the overall user experience.

Closes #146