### PR TITLE
feat(notifications): Implement Web Push Notifications for New Visitors

### DIFF
--- a/client/components/features/settings/SettingsFormSection.jsx
+++ b/client/components/features/settings/SettingsFormSection.jsx
@@ -15,6 +15,7 @@ import {
 import { FaCheckCircle } from "react-icons/fa"
 import { LuCircleAlert, LuSettings } from "react-icons/lu"
 import { FormField, LanguageSelect, Link, ThemeSelector } from "@/components/ui"
+import { usePushNotification } from "@/contexts/PushNotificationContext"
 import { useSettingsForm } from "@/hooks/form"
 import { useIntl } from "@/hooks/utils"
 import { TokenGenerator } from "./TokenGenerator"
@@ -29,6 +30,16 @@ export function SettingsFormSection({ onSuccess }) {
     mailTransportValidating,
     mailTransportValid,
   } = useSettingsForm()
+
+  const {
+    isSupported,
+    permission,
+    isSubscribed,
+    isLoading: isEnabling,
+    subscribe,
+    unsubscribe,
+    canSubscribe,
+  } = usePushNotification()
 
   const handleSubmit = async (data) => {
     const result = await onSubmit(data)
@@ -206,9 +217,38 @@ export function SettingsFormSection({ onSuccess }) {
         >
           <LuSettings /> {t("settings.saveSettings")}
         </Button>
-
         <Separator />
 
+        {/* 通知设置 */}
+        <VStack align="stretch" gap={2}>
+          <HStack justify="space-between">
+            <VStack align="start" gap={1}>
+              <Text fontSize="sm" fontWeight="medium">
+                {t("settings.enablePushNotification")}
+              </Text>
+              <Text fontSize="xs" color="gray.500">
+                {permission === "denied"
+                  ? t("settings.pushNotificationDenied")
+                  : t("settings.enablePushNotificationHelper")}
+              </Text>
+            </VStack>
+            <Switch.Root
+              checked={isSubscribed}
+              disabled={!isSupported || !canSubscribe || isEnabling}
+              onCheckedChange={async (details) => {
+                if (!details.checked) {
+                  await unsubscribe()
+                } else {
+                  await subscribe()
+                }
+              }}
+            >
+              <Switch.HiddenInput />
+              <Switch.Control />
+            </Switch.Root>
+          </HStack>
+        </VStack>
+        <Separator />
         {/* Token 生成功能 */}
         <VStack align="stretch" gap={4}>
           <VStack align="start" gap={1}>

--- a/client/components/layout/Footer.jsx
+++ b/client/components/layout/Footer.jsx
@@ -61,160 +61,152 @@ export const Footer = () => {
     : t("common.unknown")
 
   return (
-    <>
-      <Center
-        bgColor={"gray.100"}
-        color={"gray.600"}
-        _dark={{
-          bgColor: "rgba(26, 32, 44, 0.8)",
-          color: "gray.300",
-          borderColor: "gray.600",
-        }}
-        p={2}
-        borderTop="1px solid"
-        borderColor="gray.200"
-      >
-        <Container maxW="6xl">
-          <HStack justify="space-between" w="full">
-            {/* 左侧：Logo */}
-            <Link
-              href="https://github.com/epressworld/epress"
-              target="_blank"
-              rel="noopener noreferrer"
-              _hover={{ opacity: 0.8 }}
-            >
-              <Image
-                src="/assets/logo-light.svg"
-                alt="epress logo"
-                width={16}
-              />
-            </Link>
+    <Center
+      bgColor={"gray.100"}
+      color={"gray.600"}
+      _dark={{
+        bgColor: "rgba(26, 32, 44, 0.8)",
+        color: "gray.300",
+        borderColor: "gray.600",
+      }}
+      p={2}
+      borderTop="1px solid"
+      borderColor="gray.200"
+    >
+      <Container maxW="6xl">
+        <HStack justify="space-between" w="full">
+          {/* 左侧：Logo */}
+          <Link
+            href="https://github.com/epressworld/epress"
+            target="_blank"
+            rel="noopener noreferrer"
+            _hover={{ opacity: 0.8 }}
+          >
+            <Image src="/assets/logo-light.svg" alt="epress logo" width={16} />
+          </Link>
 
-            {/* 右侧：在线访客 + 运行状态 */}
-            <HStack gap={3}>
-              {/* 在线访客按钮 */}
-              <OnlineVisitorsButton />
+          {/* 右侧：在线访客 + 运行状态 */}
+          <HStack gap={3}>
+            {/* 在线访客按钮 */}
+            <OnlineVisitorsButton />
 
-              {/* 运行状态按钮 */}
-              <Popover.Root placement="top">
-                <Popover.Trigger asChild>
-                  <Button variant="plain" color="fg.muted" size="sm" px={0}>
-                    <HStack gap={1}>
-                      <Text fontSize="sm">
-                        {t("common.onlineDays", { days: runningDays })}
-                      </Text>
-                      <Box
-                        w={3}
-                        h={3}
-                        borderRadius="full"
-                        bgColor="green.500"
-                        flexShrink={0}
-                      />
-                    </HStack>
-                  </Button>
-                </Popover.Trigger>
-                <Popover.Positioner>
-                  <Popover.Content maxW="md">
-                    <Popover.Arrow />
-                    <Popover.Body>
-                      <VStack gap={4} align="stretch">
-                        {/* 版本信息 */}
-                        <VStack gap={2} align="start">
-                          <HStack gap={2}>
-                            <FaCodeBranch size={16} />
-                            <Text fontWeight="semibold">
-                              {t("common.version")}
-                            </Text>
-                          </HStack>
-                          <Text
-                            fontSize="sm"
-                            color="gray.600"
-                            _dark={{ color: "gray.300" }}
-                          >
-                            v{nodeStatus.version || "..."}
-                            <Badge ml={1} colorPalette={"orange"}>
-                              Beta
-                            </Badge>
+            {/* 运行状态按钮 */}
+            <Popover.Root placement="top">
+              <Popover.Trigger asChild>
+                <Button variant="plain" color="fg.muted" size="sm" px={0}>
+                  <HStack gap={1}>
+                    <Text fontSize="sm">
+                      {t("common.onlineDays", { days: runningDays })}
+                    </Text>
+                    <Box
+                      w={3}
+                      h={3}
+                      borderRadius="full"
+                      bgColor="green.500"
+                      flexShrink={0}
+                    />
+                  </HStack>
+                </Button>
+              </Popover.Trigger>
+              <Popover.Positioner>
+                <Popover.Content maxW="md">
+                  <Popover.Arrow />
+                  <Popover.Body>
+                    <VStack gap={4} align="stretch">
+                      {/* 版本信息 */}
+                      <VStack gap={2} align="start">
+                        <HStack gap={2}>
+                          <FaCodeBranch size={16} />
+                          <Text fontWeight="semibold">
+                            {t("common.version")}
                           </Text>
-                        </VStack>
-
-                        <Separator />
-
-                        {/* 以太坊地址 */}
-                        <VStack gap={2} align="start">
-                          <HStack gap={2}>
-                            <SiEthereum size={16} />
-                            <Text fontWeight="semibold">
-                              {t("common.ethereumAddress")}
-                            </Text>
-                          </HStack>
-                          <Text
-                            fontFamily="mono"
-                            fontSize="sm"
-                            color="gray.600"
-                            _dark={{ color: "gray.300" }}
-                            wordBreak="break-all"
-                          >
-                            {profile.address || "..."}
-                          </Text>
-                        </VStack>
-
-                        <Separator />
-
-                        {/* 安装时间 */}
-                        <VStack gap={2} align="start">
-                          <HStack gap={2}>
-                            <LuCalendar size={16} />
-                            <Text fontWeight="semibold">
-                              {t("common.installTime")}
-                            </Text>
-                          </HStack>
-                          <Text
-                            fontSize="sm"
-                            color="gray.600"
-                            _dark={{ color: "gray.300" }}
-                          >
-                            {formattedInstallDate}
-                          </Text>
-                        </VStack>
-
-                        <Separator />
-
-                        {/* 运行天数 */}
-                        <VStack gap={2} align="start">
-                          <HStack gap={2}>
-                            <LuClock size={16} />
-                            <Text fontWeight="semibold">
-                              {t("common.runningDays")}
-                            </Text>
-                          </HStack>
-                          <HStack gap={2}>
-                            <Badge colorPalette="green" variant="solid">
-                              {t("common.daysWithCount", {
-                                count: runningDays,
-                              })}
-                            </Badge>
-                            <Text
-                              fontSize="sm"
-                              color="gray.600"
-                              _dark={{ color: "gray.300" }}
-                            >
-                              ({t("common.sinceWithTime", { time: uptimeText })}
-                              )
-                            </Text>
-                          </HStack>
-                        </VStack>
+                        </HStack>
+                        <Text
+                          fontSize="sm"
+                          color="gray.600"
+                          _dark={{ color: "gray.300" }}
+                        >
+                          v{nodeStatus.version || "..."}
+                          <Badge ml={1} colorPalette={"orange"}>
+                            Beta
+                          </Badge>
+                        </Text>
                       </VStack>
-                    </Popover.Body>
-                  </Popover.Content>
-                </Popover.Positioner>
-              </Popover.Root>
-            </HStack>
-          </HStack>
-        </Container>
-      </Center>
 
+                      <Separator />
+
+                      {/* 以太坊地址 */}
+                      <VStack gap={2} align="start">
+                        <HStack gap={2}>
+                          <SiEthereum size={16} />
+                          <Text fontWeight="semibold">
+                            {t("common.ethereumAddress")}
+                          </Text>
+                        </HStack>
+                        <Text
+                          fontFamily="mono"
+                          fontSize="sm"
+                          color="gray.600"
+                          _dark={{ color: "gray.300" }}
+                          wordBreak="break-all"
+                        >
+                          {profile.address || "..."}
+                        </Text>
+                      </VStack>
+
+                      <Separator />
+
+                      {/* 安装时间 */}
+                      <VStack gap={2} align="start">
+                        <HStack gap={2}>
+                          <LuCalendar size={16} />
+                          <Text fontWeight="semibold">
+                            {t("common.installTime")}
+                          </Text>
+                        </HStack>
+                        <Text
+                          fontSize="sm"
+                          color="gray.600"
+                          _dark={{ color: "gray.300" }}
+                        >
+                          {formattedInstallDate}
+                        </Text>
+                      </VStack>
+
+                      <Separator />
+
+                      {/* 运行天数 */}
+                      <VStack gap={2} align="start">
+                        <HStack gap={2}>
+                          <LuClock size={16} />
+                          <Text fontWeight="semibold">
+                            {t("common.runningDays")}
+                          </Text>
+                        </HStack>
+                        <HStack gap={2}>
+                          <Badge colorPalette="green" variant="solid">
+                            {t("common.daysWithCount", {
+                              count: runningDays,
+                            })}
+                          </Badge>
+                          <Text
+                            fontSize="sm"
+                            color="gray.600"
+                            _dark={{ color: "gray.300" }}
+                          >
+                            ({t("common.sinceWithTime", { time: uptimeText })})
+                          </Text>
+                        </HStack>
+                      </VStack>
+                    </VStack>
+                  </Popover.Body>
+                </Popover.Content>
+              </Popover.Positioner>
+            </Popover.Root>
+          </HStack>
+        </HStack>
+      </Container>
       <Toaster />
-    </>
+    </Center>
   )
 }

--- a/client/components/layout/Page.jsx
+++ b/client/components/layout/Page.jsx
@@ -6,6 +6,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from "react"
 import { AuthProvider } from "@/contexts/AuthContext"
 import { OnlineVisitorsProvider } from "@/contexts/OnlineVisitorsContext"
 import { PageContext } from "@/contexts/PageContext"
+import { PushNotificationProvider } from "@/contexts/PushNotificationContext"
 import { PAGE_DATA } from "@/lib/apollo/queries"
 import { ChakraProvider, WagmiProvider } from "../providers"
 import { Footer } from "./Footer"
@@ -65,17 +66,26 @@ export function Page({ children, intl, initialAuthState }) {
         >
           <ChakraProvider defaultTheme={value.settings.defaultTheme}>
             <AuthProvider initialAuthState={initialAuthState}>
-              <OnlineVisitorsProvider>
-                <div className="layout-container page-container">
-                  <Header />
-                  <main className="content-area">
-                    <Container maxW="6xl" py={6}>
-                      <Suspense fallback={null}>{children}</Suspense>
-                    </Container>
-                  </main>
-                  <Footer />
-                </div>
-              </OnlineVisitorsProvider>
+              <PushNotificationProvider>
+                <OnlineVisitorsProvider>
+                  <div className="layout-container page-container">
+                    <main
+                      className="content-area"
+                      style={{
+                        minHeight: "100vh",
+                        display: "flex",
+                        flexDirection: "column",
+                      }}
+                    >
+                      <Header />
+                      <Container maxW="6xl" py={6} flex={1}>
+                        <Suspense fallback={null}>{children}</Suspense>
+                      </Container>
+                      <Footer />
+                    </main>
+                  </div>
+                </OnlineVisitorsProvider>
+              </PushNotificationProvider>
             </AuthProvider>
           </ChakraProvider>
         </WagmiProvider>

--- a/client/contexts/PushNotificationContext.jsx
+++ b/client/contexts/PushNotificationContext.jsx
@@ -1,0 +1,281 @@
+"use client"
+
+import { useMutation } from "@apollo/client/react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+import { useAuth } from "@/contexts/AuthContext"
+import { usePage } from "@/contexts/PageContext"
+import { SUBSCRIBE_NOTIFICATION, UNSUBSCRIBE_NOTIFICATION } from "@/lib/apollo"
+import {
+  formatSubscriptionForServer,
+  getCurrentSubscription,
+  getNotificationPermission,
+  isPushNotificationSupported,
+  isSubscriptionValid,
+  requestNotificationPermission,
+  subscribeToPushNotifications,
+  unsubscribeFromPushNotifications,
+} from "@/utils/helpers/pushNotificaiton"
+
+const PushNotificationContext = createContext()
+
+export function PushNotificationProvider({ children }) {
+  const { settings } = usePage()
+  const { authStatus, AUTH_STATUS, isNodeOwner } = useAuth()
+
+  const [isSupported, setIsSupported] = useState(false)
+  const [permission, setPermission] = useState("default")
+  const [subscription, setSubscription] = useState(null)
+  const [isSubscribed, setIsSubscribed] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [isClient, setIsClient] = useState(false)
+
+  const [subscribeNotification] = useMutation(SUBSCRIBE_NOTIFICATION)
+  const [unsubscribeNotification] = useMutation(UNSUBSCRIBE_NOTIFICATION)
+
+  // 检测客户端环境
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  // 初始化：检查浏览器支持和当前状态
+  useEffect(() => {
+    if (!isClient) return
+
+    const initPushNotification = async () => {
+      // 检查浏览器支持
+      const supported = isPushNotificationSupported()
+      setIsSupported(supported)
+
+      if (!supported) {
+        console.log("Push notifications are not supported")
+        return
+      }
+
+      // 获取当前权限状态
+      const currentPermission = getNotificationPermission()
+      setPermission(currentPermission)
+
+      // 如果已授权，检查现有订阅
+      if (currentPermission === "granted") {
+        try {
+          const currentSubscription = await getCurrentSubscription()
+          if (currentSubscription && isSubscriptionValid(currentSubscription)) {
+            setSubscription(currentSubscription)
+            setIsSubscribed(true)
+          } else {
+            setIsSubscribed(false)
+          }
+        } catch (error) {
+          console.error("Failed to get current subscription:", error)
+        }
+      }
+    }
+
+    initPushNotification()
+  }, [isClient])
+
+  useEffect(() => {
+    if (!isClient || typeof navigator === "undefined") return
+
+    const handleMessage = (event) => {
+      if (event.data?.type === "PUSH_SUBSCRIPTION_CHANGED") {
+        // 订阅已更改，重新保存
+        const newSubscription = event.data.subscription
+        if (newSubscription) {
+          handleSubscriptionChange(newSubscription).catch((error) => {
+            console.error("Failed to handle subscription change:", error)
+          })
+        }
+      }
+    }
+
+    navigator.serviceWorker?.addEventListener("message", handleMessage)
+
+    return () => {
+      navigator.serviceWorker?.removeEventListener("message", handleMessage)
+    }
+  }, [isClient])
+
+  // 处理订阅变化
+  const handleSubscriptionChange = async (newSubscription) => {
+    try {
+      const formattedSubscription = formatSubscriptionForServer(newSubscription)
+      await subscribeNotification({
+        variables: { subscription: formattedSubscription },
+      })
+      setSubscription(newSubscription)
+      setIsSubscribed(true)
+      console.log("Subscription updated successfully")
+    } catch (error) {
+      console.error("Failed to save updated subscription:", error)
+    }
+  }
+
+  // 订阅推送通知
+  const subscribe = useCallback(async () => {
+    if (!isClient) {
+      throw new Error(
+        "Push notification subscription is only available on the client",
+      )
+    }
+
+    if (!isSupported) {
+      throw new Error("Push notifications are not supported in this browser")
+    }
+
+    if (!settings?.vapidPublicKey) {
+      throw new Error("VAPID public key is not configured")
+    }
+
+    if (!isNodeOwner) {
+      throw new Error("Only node owner can subscribe to push notifications")
+    }
+
+    if (authStatus !== AUTH_STATUS.AUTHENTICATED) {
+      throw new Error("You must be authenticated to subscribe")
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      // 请求通知权限
+      let currentPermission = permission
+      if (currentPermission !== "granted") {
+        currentPermission = await requestNotificationPermission()
+        setPermission(currentPermission)
+      }
+
+      if (currentPermission !== "granted") {
+        throw new Error("Notification permission denied")
+      }
+
+      // 订阅推送通知
+      const newSubscription = await subscribeToPushNotifications(
+        settings.vapidPublicKey,
+      )
+
+      // 保存订阅到服务器
+      const formattedSubscription = formatSubscriptionForServer(newSubscription)
+      await subscribeNotification({
+        variables: { subscription: formattedSubscription },
+      })
+
+      setSubscription(newSubscription)
+      setIsSubscribed(true)
+      setIsLoading(false)
+
+      return newSubscription
+    } catch (error) {
+      console.error("Failed to subscribe to push notifications:", error)
+      setError(error.message)
+      setIsLoading(false)
+      throw error
+    }
+  }, [
+    isClient,
+    isSupported,
+    settings?.vapidPublicKey,
+    isNodeOwner,
+    authStatus,
+    AUTH_STATUS.AUTHENTICATED,
+    permission,
+    subscribeNotification,
+  ])
+
+  // 取消订阅
+  const unsubscribe = useCallback(async () => {
+    if (!isClient) {
+      throw new Error("Unsubscribe is only available on the client")
+    }
+
+    if (!isSupported) {
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const subscription = await getCurrentSubscription()
+      await unsubscribeNotification({
+        variables: { endpoint: subscription.endpoint },
+      })
+      const success = await unsubscribeFromPushNotifications()
+      if (success) {
+        setSubscription(null)
+        setIsSubscribed(false)
+      }
+      setIsLoading(false)
+      return success
+    } catch (error) {
+      console.error("Failed to unsubscribe from push notifications:", error)
+      setError(error.message)
+      setIsLoading(false)
+      throw error
+    }
+  }, [isClient, isSupported])
+
+  // 检查并更新订阅状态
+  const checkSubscription = useCallback(async () => {
+    if (!isClient || !isSupported) return
+
+    try {
+      const currentSubscription = await getCurrentSubscription()
+      if (currentSubscription && isSubscriptionValid(currentSubscription)) {
+        setSubscription(currentSubscription)
+        setIsSubscribed(true)
+      } else {
+        setSubscription(null)
+        setIsSubscribed(false)
+      }
+    } catch (error) {
+      console.error("Failed to check subscription:", error)
+    }
+  }, [isClient, isSupported])
+
+  const value = {
+    // 状态
+    isSupported,
+    permission,
+    subscription,
+    isSubscribed,
+    isLoading,
+    error,
+
+    // 操作
+    subscribe,
+    unsubscribe,
+    checkSubscription,
+
+    // 辅助信息
+    canSubscribe:
+      isSupported &&
+      isNodeOwner &&
+      authStatus === AUTH_STATUS.AUTHENTICATED &&
+      !!settings?.vapidPublicKey,
+  }
+
+  return (
+    <PushNotificationContext.Provider value={value}>
+      {children}
+    </PushNotificationContext.Provider>
+  )
+}
+
+export function usePushNotification() {
+  const context = useContext(PushNotificationContext)
+  if (!context) {
+    throw new Error(
+      "usePushNotification must be used within a PushNotificationProvider",
+    )
+  }
+  return context
+}

--- a/client/lib/apollo/mutations.js
+++ b/client/lib/apollo/mutations.js
@@ -140,6 +140,24 @@ export const UPDATE_SETTINGS = gql`
   }
 `
 
+// Push Notification mutations
+export const SUBSCRIBE_NOTIFICATION = gql`
+  mutation SubscribeNotification($subscription: PushSubscriptionInput!) {
+    subscribeNotification(subscription: $subscription) {
+      success
+      message
+    }
+  }
+`
+export const UNSUBSCRIBE_NOTIFICATION = gql`
+  mutation UnsubscribeNotification($endpoint: String!) {
+    unsubscribeNotification(endpoint: $endpoint) {
+      success
+      message
+    }
+  }
+`
+
 // Comment mutations
 export const CREATE_COMMENT = gql`
   mutation CreateComment($input: CreateCommentInput!) {

--- a/client/lib/apollo/queries.js
+++ b/client/lib/apollo/queries.js
@@ -264,6 +264,7 @@ export const SETTINGS = gql`
       enableRSS
       allowFollow
       allowComment
+      vapidPublicKey
     }
   }
 `
@@ -302,6 +303,7 @@ export const PAGE_DATA = gql`
       defaultLanguage
       defaultTheme
       walletConnectProjectId
+      vapidPublicKey
       mail {
         enabled
         mailTransport

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -364,7 +364,10 @@
     "fetchComments": "Get Comments",
     "deleteComments": "Delete Comments",
     "titleRequired": "Title is required",
-    "pleaseLoginFirst": "Please login first"
+    "pleaseLoginFirst": "Please login first",
+    "enablePushNotification": "Enable Push Notifications",
+    "pushNotificationDenied": "Permission Denied",
+    "enablePushNotificationHelper": "This setting only applies to the current device"
   },
   "error": {
     "pageNotFound": "Page Not Found",

--- a/client/messages/zh.json
+++ b/client/messages/zh.json
@@ -364,7 +364,10 @@
     "fetchComments": "获取评论",
     "deleteComments": "删除评论",
     "titleRequired": "标题不能为空",
-    "pleaseLoginFirst": "请先登录"
+    "pleaseLoginFirst": "请先登录",
+    "enablePushNotification": "启用推送通知",
+    "pushNotificationDenied": "权限已禁用",
+    "enablePushNotificationHelper": "本设置只对当前设备有效"
   },
   "error": {
     "pageNotFound": "页面未找到",

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,6 +1,4 @@
-// public/sw.js - 最终修复版
-
-const CACHE_NAME = "epress-v2" // 更新缓存名称以触发更新
+const CACHE_NAME = "epress" // 更新缓存名称以触发更新
 const urlsToCache = ["/", "/publications", "/connections", "/manifest.json"]
 
 // 监听 install 事件，在其中缓存 App Shell
@@ -32,7 +30,7 @@ self.addEventListener("activate", (event) => {
   return self.clients.claim()
 })
 
-// 监听 fetch 事件，应用“网络优先”策略，但对 Range Request 特殊处理
+// 监听 fetch 事件，应用"网络优先"策略，但对 Range Request 特殊处理
 self.addEventListener("fetch", (event) => {
   // 我们只处理 GET 请求
   if (event.request.method !== "GET") {
@@ -46,7 +44,7 @@ self.addEventListener("fetch", (event) => {
     return
   }
 
-  // --- 对非 Range Request 沿用“网络优先”策略 ---
+  // --- 对非 Range Request 沿用"网络优先"策略 ---
   event.respondWith(
     fetch(event.request)
       .then((networkResponse) => {
@@ -63,6 +61,135 @@ self.addEventListener("fetch", (event) => {
       .catch(() => {
         // 网络请求失败，尝试从缓存中返回
         return caches.match(event.request)
+      }),
+  )
+})
+
+// --- 推送通知功能 ---
+
+/**
+ * 监听推送事件
+ * 当服务器发送推送通知时触发
+ */
+self.addEventListener("push", (event) => {
+  console.log("Push notification received:", event)
+  const defaultNotificationData = {
+    title: "New Notification",
+    body: "You have a new notification",
+    icon: "/icons/icon-192x192.png",
+    badge: "/icons/icon-72x72.png",
+    tag: "default",
+    data: {
+      url: "/",
+    },
+  }
+
+  let notificationData = {}
+
+  // 解析推送数据
+  if (event.data) {
+    try {
+      notificationData = { ...defaultNotificationData, ...event.data.json() }
+    } catch (error) {
+      console.error("Failed to parse push data:", error)
+      notificationData = { ...defaultNotificationData, body: event.data.text() }
+    }
+  }
+
+  // 显示通知
+  const notificationPromise = self.registration.showNotification(
+    notificationData.title,
+    {
+      body: notificationData.body,
+      icon: notificationData.icon,
+      badge: notificationData.badge,
+      tag: notificationData.tag,
+      data: notificationData.data,
+      requireInteraction: false,
+      vibrate: [200, 100, 200],
+    },
+  )
+
+  event.waitUntil(
+    notificationPromise.catch((error) => {
+      // [重要] 在 Service Worker 控制台打印出失败的确切原因
+      console.error("Failed to show notification:", error)
+    }),
+  )
+})
+
+/**
+ * 监听通知点击事件
+ * 当用户点击通知时触发
+ */
+self.addEventListener("notificationclick", (event) => {
+  console.log("Notification clicked:", event)
+
+  // 关闭通知
+  event.notification.close()
+
+  // 获取要打开的 URL
+  const urlToOpen = event.notification.data?.url || "/"
+
+  // 打开或聚焦到应用页面
+  event.waitUntil(
+    clients
+      .matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      })
+      .then((clientList) => {
+        // 尝试找到已打开的匹配窗口
+        for (const client of clientList) {
+          if (client.url.includes(urlToOpen) && "focus" in client) {
+            return client.focus()
+          }
+        }
+
+        // 如果没有找到匹配窗口，打开新窗口
+        if (clients.openWindow) {
+          return clients.openWindow(urlToOpen)
+        }
+      }),
+  )
+})
+
+/**
+ * 监听通知关闭事件
+ * 当通知被关闭时触发（可选）
+ */
+self.addEventListener("notificationclose", (event) => {
+  console.log("Notification closed:", event)
+  // 可以在这里记录用户关闭通知的行为
+})
+
+/**
+ * 监听推送订阅变化事件
+ * 当推送订阅失效时触发
+ */
+self.addEventListener("pushsubscriptionchange", (event) => {
+  console.log("Push subscription changed:", event)
+
+  // 尝试重新订阅
+  event.waitUntil(
+    self.registration.pushManager
+      .subscribe(event.oldSubscription.options)
+      .then((subscription) => {
+        console.log("Resubscribed to push notifications:", subscription)
+        // 这里可以将新订阅发送到服务器
+        // 但由于我们在 Service Worker 中，无法直接调用 GraphQL
+        // 需要通过 postMessage 通知客户端页面
+        return self.clients.matchAll().then((clients) => {
+          clients.forEach((client) => {
+            client.postMessage({
+              type: "PUSH_SUBSCRIPTION_CHANGED",
+              subscription: subscription.toJSON(),
+            })
+          })
+        })
+      })
+      .catch((error) => {
+        console.error("Failed to resubscribe:", error)
       }),
   )
 })

--- a/client/utils/helpers/pushNotificaiton.js
+++ b/client/utils/helpers/pushNotificaiton.js
@@ -1,0 +1,193 @@
+/**
+ * 将 Base64 编码的 VAPID 公钥转换为 Uint8Array
+ * @param {string} base64String - Base64 编码的字符串
+ * @returns {Uint8Array}
+ */
+export function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/")
+
+  const rawData = window.atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+/**
+ * 将 ArrayBuffer 转换为 Base64 字符串
+ * @param {ArrayBuffer} buffer
+ * @returns {string}
+ */
+export function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer)
+  let binary = ""
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return window.btoa(binary)
+}
+
+/**
+ * 检查浏览器是否支持推送通知
+ * @returns {boolean}
+ */
+export function isPushNotificationSupported() {
+  return (
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    "Notification" in window
+  )
+}
+
+/**
+ * 获取当前的通知权限状态
+ * @returns {NotificationPermission} 'default' | 'granted' | 'denied'
+ */
+export function getNotificationPermission() {
+  if (!isPushNotificationSupported()) {
+    return "default"
+  }
+  return Notification.permission
+}
+
+/**
+ * 请求通知权限
+ * @returns {Promise<NotificationPermission>}
+ */
+export async function requestNotificationPermission() {
+  if (!isPushNotificationSupported()) {
+    throw new Error("Push notifications are not supported in this browser")
+  }
+
+  const permission = await Notification.requestPermission()
+  return permission
+}
+
+/**
+ * 获取当前的推送订阅
+ * @returns {Promise<PushSubscription | null>}
+ */
+export async function getCurrentSubscription() {
+  if (!isPushNotificationSupported()) {
+    return null
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const subscription = await registration.pushManager.getSubscription()
+    return subscription
+  } catch (error) {
+    console.error("Failed to get current subscription:", error)
+    return null
+  }
+}
+
+/**
+ * 订阅推送通知
+ * @param {string} vapidPublicKey - VAPID 公钥
+ * @returns {Promise<PushSubscription>}
+ */
+export async function subscribeToPushNotifications(vapidPublicKey) {
+  if (!isPushNotificationSupported()) {
+    throw new Error("Push notifications are not supported in this browser")
+  }
+
+  if (!vapidPublicKey) {
+    throw new Error("VAPID public key is required")
+  }
+
+  try {
+    // 等待 Service Worker 准备就绪
+    const registration = await navigator.serviceWorker.ready
+
+    // 检查是否已有订阅
+    let subscription = await registration.pushManager.getSubscription()
+
+    // 如果已有订阅，先取消
+    if (subscription) {
+      await subscription.unsubscribe()
+    }
+
+    // 创建新订阅
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+    })
+
+    return subscription
+  } catch (error) {
+    console.error("Failed to subscribe to push notifications:", error)
+    throw error
+  }
+}
+
+/**
+ * 取消推送订阅
+ * @returns {Promise<boolean>}
+ */
+export async function unsubscribeFromPushNotifications() {
+  if (!isPushNotificationSupported()) {
+    return false
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    const subscription = await registration.pushManager.getSubscription()
+
+    if (subscription) {
+      const successful = await subscription.unsubscribe()
+      return successful
+    }
+
+    return true
+  } catch (error) {
+    console.error("Failed to unsubscribe from push notifications:", error)
+    return false
+  }
+}
+
+/**
+ * 将 PushSubscription 对象转换为服务器需要的格式
+ * @param {PushSubscription} subscription
+ * @returns {Object}
+ */
+export function formatSubscriptionForServer(subscription) {
+  const key = subscription.getKey("p256dh")
+  const token = subscription.getKey("auth")
+
+  return {
+    endpoint: subscription.endpoint,
+    keys: {
+      p256dh: arrayBufferToBase64(key),
+      auth: arrayBufferToBase64(token),
+    },
+  }
+}
+
+/**
+ * 检查订阅是否有效
+ * @param {PushSubscription} subscription
+ * @returns {boolean}
+ */
+export function isSubscriptionValid(subscription) {
+  if (!subscription) {
+    return false
+  }
+
+  // 检查订阅是否有 endpoint
+  if (!subscription.endpoint) {
+    return false
+  }
+
+  // 检查订阅是否有必要的密钥
+  try {
+    const p256dh = subscription.getKey("p256dh")
+    const auth = subscription.getKey("auth")
+    return !!(p256dh && auth)
+  } catch (_error) {
+    return false
+  }
+}

--- a/deploy/seeds/010_initial_data.mjs
+++ b/deploy/seeds/010_initial_data.mjs
@@ -1,4 +1,5 @@
 import crypto from "node:crypto"
+import webpush from "web-push"
 
 /**
  * @param { import("knex").Knex } knex
@@ -17,7 +18,7 @@ export const seed = async (knex) => {
     created_at: new Date(),
     updated_at: new Date(),
   })
-
+  const vapidKeys = webpush.generateVAPIDKeys()
   // 插入设置记录
   const settingsToInsert = [
     { key: "enable_rss", value: "true" },
@@ -43,6 +44,8 @@ export const seed = async (knex) => {
     { key: "avatar", value: process.env.INITIAL_DATA_NODE_AVATAR || "" },
     { key: "jwt_secret", value: crypto.randomBytes(32).toString("hex") },
     { key: "jwt_expires_in", value: "24h" },
+    { key: "notification_vapid_keys", value: JSON.stringify(vapidKeys) },
+    { key: "notification_subscriptions", value: "[]" },
   ]
 
   // 批量插入设置

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "validator": "^13.15.20",
         "viem": "^2.38.4",
         "wagmi": "^2.18.2",
+        "web-push": "^3.6.7",
         "yet-another-react-lightbox": "^3.25.0"
       },
       "devDependencies": {
@@ -96,7 +97,8 @@
         "knex": "^3.1.0",
         "lint-staged": "^16.2.6",
         "nock": "^14.0.10",
-        "nodemon": "^3.1.4"
+        "nodemon": "^3.1.4",
+        "sinon": "^21.0.0"
       }
     },
     "node_modules/@actions/core": {
@@ -4280,6 +4282,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -7193,7 +7236,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -9770,6 +9812,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
@@ -11966,6 +12018,15 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -12027,7 +12088,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -19079,6 +19139,24 @@
         "safe-stable-stringify": "^2.4.3"
       }
     },
+    "node_modules/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/siwe": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/siwe/-/siwe-3.0.0.tgz",
@@ -20103,6 +20181,16 @@
         "node": "*"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -20913,6 +21001,46 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/web-push/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/web-resource-inliner": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "validator": "^13.15.20",
     "viem": "^2.38.4",
     "wagmi": "^2.18.2",
+    "web-push": "^3.6.7",
     "yet-another-react-lightbox": "^3.25.0"
   },
   "devDependencies": {
@@ -107,7 +108,8 @@
     "knex": "^3.1.0",
     "lint-staged": "^16.2.6",
     "nock": "^14.0.10",
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "sinon": "^21.0.0"
   },
   "ava": {
     "timeout": "120s",

--- a/server/graphql/mutations/index.mjs
+++ b/server/graphql/mutations/index.mjs
@@ -3,12 +3,13 @@ import { commentMutations } from "./comment.mjs"
 import { connectionMutations } from "./connection.mjs"
 import { updateProfileMutation } from "./profile.mjs"
 import { publicationMutations } from "./publication.mjs"
-import { updateSettingsMutation } from "./settings.mjs"
+import { notificationMutation, updateSettingsMutation } from "./settings.mjs"
 
 export default {
   ...authMutations,
   ...updateProfileMutation,
   ...updateSettingsMutation,
+  ...notificationMutation,
   ...publicationMutations,
   ...connectionMutations,
   ...commentMutations,

--- a/server/graphql/queries/settings.mjs
+++ b/server/graphql/queries/settings.mjs
@@ -23,6 +23,7 @@ const SettingsType = graphql.type("ObjectType", {
     defaultTheme: { type: graphql.type("NonNull", graphql.type("String")) },
     walletConnectProjectId: { type: graphql.type("String") },
     mail: { type: graphql.type("NonNull", MailType) },
+    vapidPublicKey: { type: graphql.type("String") },
   },
 })
 
@@ -47,6 +48,7 @@ const settingsQuery = {
         walletConnectProjectId: null,
         mailTransport: "",
         mailFrom: "",
+        vapidPublicKey: null,
       }
 
       // 检查邮件是否已配置
@@ -73,6 +75,8 @@ const settingsQuery = {
           mailTransport: context.user ? mailTransport : null,
           mailFrom: context.user ? mailFrom : null,
         },
+        // VAPID 公钥 - 所有人都可以访问
+        vapidPublicKey: allSettings.notification_vapid_keys?.publicKey,
       }
 
       request.log.debug(

--- a/server/utils/email/index.mjs
+++ b/server/utils/email/index.mjs
@@ -7,6 +7,9 @@ import nodemailer from "nodemailer"
 import { Setting } from "../../models/index.mjs"
 
 let transporter = null
+export function setTransporter(t) {
+  transporter = t
+}
 
 /**
  * Get email transporter
@@ -25,7 +28,7 @@ export async function getTransporter(config) {
       )
     }
 
-    transporter = nodemailer.createTransport(mailTransport)
+    setTransporter(nodemailer.createTransport(mailTransport))
   }
   return transporter
 }

--- a/server/utils/webpush.mjs
+++ b/server/utils/webpush.mjs
@@ -1,0 +1,103 @@
+import webpush from "web-push"
+import { Setting } from "../models/index.mjs"
+
+/**
+ * 发送Web推送通知给节点所有者
+ * @param {string} visitorAddress - 新访客的以太坊地址
+ * @param {object} log - 日志记录器
+ */
+export async function sendPushNotification(msg, log = console) {
+  try {
+    // 获取VAPID密钥
+    const vapidKeys = await Setting.get("notification_vapid_keys")
+
+    if (!vapidKeys) {
+      log.warn("VAPID keys not configured, skipping push notification")
+      return
+    }
+
+    // 获取订阅列表
+    const subscriptions = await Setting.get("notification_subscriptions")
+
+    if (!subscriptions) {
+      log.debug("No subscriptions found, skipping push notification")
+      return
+    }
+
+    try {
+      if (!Array.isArray(subscriptions) || subscriptions.length === 0) {
+        log.debug("No valid subscriptions found")
+        return
+      }
+    } catch (parseError) {
+      log.error("Failed to parse subscriptions:", parseError)
+      return
+    }
+
+    // 配置VAPID详情
+    webpush.setVapidDetails(
+      "https://epress.blog", // 可以从设置中获取
+      vapidKeys.publicKey,
+      vapidKeys.privateKey,
+    )
+
+    // 发送到所有订阅
+    const invalidSubscriptions = []
+    const sendPromises = subscriptions.map(async (subscription, index) => {
+      try {
+        await webpush.sendNotification(subscription, JSON.stringify(msg))
+        log.debug(
+          { endpoint: subscription.endpoint },
+          "Push notification sent successfully",
+        )
+      } catch (error) {
+        if (error.statusCode === 410 || error.statusCode === 404) {
+          log.info(
+            { endpoint: subscription.endpoint },
+            "Subscription expired, marking for removal",
+          )
+          invalidSubscriptions.push(index)
+        } else {
+          log.error(
+            {
+              endpoint: subscription.endpoint,
+              error: error.message,
+              statusCode: error.statusCode,
+            },
+            "Failed to send push notification",
+          )
+        }
+      }
+    })
+
+    await Promise.allSettled(sendPromises)
+
+    // 移除无效的订阅
+    if (invalidSubscriptions.length > 0) {
+      const validSubscriptions = subscriptions.filter(
+        (_, index) => !invalidSubscriptions.includes(index),
+      )
+      await Setting.set("notification_subscriptions", validSubscriptions)
+      log.info(
+        { removed: invalidSubscriptions.length },
+        "Cleaned up expired subscriptions",
+      )
+    }
+    log.info(
+      {
+        total_subscriptions: subscriptions.length,
+        invalid_subscriptions: invalidSubscriptions.length,
+      },
+      "Push notifications processing completed",
+    )
+  } catch (error) {
+    log.error(
+      {
+        error: error.message,
+        stack: error.stack,
+      },
+      "Unexpected error while sending push notification",
+    )
+    throw error
+  }
+}

--- a/test/graphql/settings.test.mjs
+++ b/test/graphql/settings.test.mjs
@@ -302,3 +302,319 @@ test.serial(
       .update({ value: "true" })
   },
 )
+
+// --- VAPID Public Key Tests ---
+
+test.serial(
+  "settings query should return vapidPublicKey when configured",
+  async (t) => {
+    const { graphqlClient } = t.context
+
+    const query = `
+    query GetSettings {
+      settings {
+        vapidPublicKey
+      }
+    }
+  `
+
+    const { data, errors } = await graphqlClient.query(query, {})
+
+    t.falsy(errors, "Should not have any GraphQL errors")
+    t.truthy(data.settings, "Settings data should exist")
+    t.true(
+      data.settings.vapidPublicKey.length > 0,
+      "vapidPublicKey should be returned",
+    )
+  },
+)
+
+test.serial(
+  "settings query should return vapidPublicKey without authentication",
+  async (t) => {
+    const { graphqlClient } = t.context
+
+    await Setting.set("notification_vapid_keys", {
+      publicKey: "test-vapid-public-key-12345",
+    })
+
+    const query = `
+    query GetSettings {
+      settings {
+        vapidPublicKey
+      }
+    }
+  `
+
+    // No authentication header
+    const { data, errors } = await graphqlClient.query(query, {})
+
+    t.falsy(errors, "Should not have any GraphQL errors")
+    t.truthy(data.settings, "Settings data should exist")
+    t.true(
+      data.settings.vapidPublicKey.length > 0,
+      "vapidPublicKey should be accessible without authentication",
+    )
+  },
+)
+
+// --- saveSubscription Mutation Tests ---
+
+test.serial(
+  "subscribeNotification should save new subscription with valid JWT",
+  async (t) => {
+    const { graphqlClient, createClientJwt } = t.context
+    const token = await createClientJwt(TEST_ETHEREUM_ADDRESS_NODE_A)
+
+    const mutation = `
+    mutation subscribe($subscription: PushSubscriptionInput!) {
+      subscribeNotification(subscription: $subscription) {
+        success
+        message
+      }
+    }
+  `
+
+    const subscription = {
+      endpoint: "https://push.example.com/subscription/test123",
+      keys: {
+        p256dh: "test-p256dh-key",
+        auth: "test-auth-key",
+      },
+    }
+
+    const { data, errors } = await graphqlClient.query(mutation, {
+      variables: { subscription },
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    t.falsy(errors, "Should not have any GraphQL errors")
+    t.truthy(data.subscribeNotification, "subscribe should return data")
+    t.true(data.subscribeNotification.success, "success should be true")
+    t.truthy(data.subscribeNotification.message, "message should exist")
+
+    // Verify subscription was saved
+    const savedSubscriptions = await Setting.get("notification_subscriptions")
+    t.truthy(savedSubscriptions, "Subscriptions should be saved")
+    t.is(savedSubscriptions.length, 1, "Should have one subscription")
+    t.is(
+      savedSubscriptions[0].endpoint,
+      subscription.endpoint,
+      "Endpoint should match",
+    )
+
+    // Cleanup
+    await Setting.set("notification_subscriptions", [])
+  },
+)
+
+test.serial(
+  "saveSubscription should return UNAUTHENTICATED without JWT",
+  async (t) => {
+    const { graphqlClient } = t.context
+
+    const mutation = `
+    mutation subscribe($subscription: PushSubscriptionInput!) {
+      subscribeNotification(subscription: $subscription) {
+        success
+        message
+      }
+    }
+  `
+
+    const subscription = {
+      endpoint: "https://push.example.com/subscription/test123",
+      keys: {
+        p256dh: "test-p256dh-key",
+        auth: "test-auth-key",
+      },
+    }
+
+    const { data, errors } = await graphqlClient.query(mutation, {
+      variables: { subscription },
+    })
+
+    t.truthy(errors, "Should return GraphQL errors")
+    t.is(data, null, "Data should be null")
+    t.true(
+      errors.some((e) => e.extensions?.code === "UNAUTHENTICATED"),
+      "Error code should be UNAUTHENTICATED",
+    )
+  },
+)
+
+test.serial(
+  "subscribeNotification should update existing subscription with same endpoint",
+  async (t) => {
+    const { graphqlClient, createClientJwt } = t.context
+    const token = await createClientJwt(TEST_ETHEREUM_ADDRESS_NODE_A)
+
+    const mutation = `
+    mutation subscribe($subscription: PushSubscriptionInput!) {
+      subscribeNotification(subscription: $subscription) {
+        success
+        message
+      }
+    }
+  `
+
+    const subscription1 = {
+      endpoint: "https://push.example.com/subscription/test123",
+      keys: {
+        p256dh: "test-p256dh-key-old",
+        auth: "test-auth-key-old",
+      },
+    }
+
+    // Save first subscription
+    await graphqlClient.query(mutation, {
+      variables: { subscription: subscription1 },
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    // Update with same endpoint but different keys
+    const subscription2 = {
+      endpoint: "https://push.example.com/subscription/test123",
+      keys: {
+        p256dh: "test-p256dh-key-new",
+        auth: "test-auth-key-new",
+      },
+    }
+
+    const { data, errors } = await graphqlClient.query(mutation, {
+      variables: { subscription: subscription2 },
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    t.falsy(errors, "Should not have any GraphQL errors")
+    t.true(data.subscribeNotification.success, "success should be true")
+
+    // Verify subscription was updated, not duplicated
+    const savedSubscriptions = await Setting.get("notification_subscriptions")
+    t.is(savedSubscriptions.length, 1, "Should still have one subscription")
+    t.is(
+      savedSubscriptions[0].keys.p256dh,
+      "test-p256dh-key-new",
+      "Keys should be updated",
+    )
+
+    // Cleanup
+    await Setting.set("notification_subscriptions", [])
+  },
+)
+
+test.serial(
+  "subscribeNotification should handle multiple subscriptions from different devices",
+  async (t) => {
+    const { graphqlClient, createClientJwt } = t.context
+    const token = await createClientJwt(TEST_ETHEREUM_ADDRESS_NODE_A)
+
+    const mutation = `
+    mutation subscribe($subscription: PushSubscriptionInput!) {
+      subscribeNotification(subscription: $subscription) {
+        success
+        message
+      }
+    }
+  `
+
+    const subscription1 = {
+      endpoint: "https://push.example.com/subscription/device1",
+      keys: {
+        p256dh: "device1-p256dh",
+        auth: "device1-auth",
+      },
+    }
+
+    const subscription2 = {
+      endpoint: "https://push.example.com/subscription/device2",
+      keys: {
+        p256dh: "device2-p256dh",
+        auth: "device2-auth",
+      },
+    }
+
+    // Save first subscription
+    await graphqlClient.query(mutation, {
+      variables: { subscription: subscription1 },
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    // Save second subscription
+    const { data, errors } = await graphqlClient.query(mutation, {
+      variables: { subscription: subscription2 },
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    t.falsy(errors, "Should not have any GraphQL errors")
+    t.true(data.subscribeNotification.success, "success should be true")
+
+    // Verify both subscriptions are saved
+    const savedSubscriptions = await Setting.get("notification_subscriptions")
+    t.is(savedSubscriptions.length, 2, "Should have two subscriptions")
+    t.truthy(
+      savedSubscriptions.find((s) => s.endpoint === subscription1.endpoint),
+      "First subscription should exist",
+    )
+    t.truthy(
+      savedSubscriptions.find((s) => s.endpoint === subscription2.endpoint),
+      "Second subscription should exist",
+    )
+
+    // Cleanup
+    await Setting.set("notification_subscriptions", [])
+  },
+)
+
+test.serial("unsubscribeNotification should remove subscription", async (t) => {
+  const { graphqlClient, createClientJwt } = t.context
+  const token = await createClientJwt(TEST_ETHEREUM_ADDRESS_NODE_A)
+
+  const subscribeMutation = `
+    mutation subscribe($subscription: PushSubscriptionInput!) {
+      subscribeNotification(subscription: $subscription) {
+        success
+        message
+      }
+    }
+  `
+  const unsubscribeMutation = `
+    mutation unsubscribe($endpoint: String!) {
+      unsubscribeNotification(endpoint: $endpoint) {
+        success
+        message
+      }
+    }
+  `
+
+  const subscription1 = {
+    endpoint: "https://push.example.com/subscription/device_to_unscribe",
+    keys: {
+      p256dh: "device1-p256dh",
+      auth: "device1-auth",
+    },
+  }
+
+  // Save first subscription
+  const { data: subscribeData } = await graphqlClient.query(subscribeMutation, {
+    variables: { subscription: subscription1 },
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  t.true(
+    subscribeData.subscribeNotification.success,
+    "subscribe should be true",
+  )
+
+  // Save second subscription
+  const { data, errors } = await graphqlClient.query(unsubscribeMutation, {
+    variables: { endpoint: subscription1.endpoint },
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  t.falsy(errors, "Should not have any GraphQL errors")
+  t.true(data.unsubscribeNotification.success, "success should be true")
+
+  // Verify both subscriptions are saved
+  const savedSubscriptions = await Setting.get("notification_subscriptions")
+  t.is(savedSubscriptions.length, 0, "Should have 0 subscriptions")
+})

--- a/test/utils/crypto.test.mjs
+++ b/test/utils/crypto.test.mjs
@@ -1,0 +1,367 @@
+import { Readable } from "node:stream"
+import test from "ava"
+import { aes, base64, hash } from "../../server/utils/crypto.mjs"
+
+test("aes.encrypt should encrypt text successfully", (t) => {
+  const testKey = "my-secret-key"
+  const testText = "Hello, World!"
+
+  const encrypted = aes.encrypt(testKey, testText)
+
+  t.truthy(encrypted)
+  t.true(encrypted.includes(":"))
+
+  const parts = encrypted.split(":")
+  t.is(parts.length, 2)
+  t.is(parts[0].length, 32) // IV is 16 bytes = 32 hex chars
+})
+
+test("aes.encrypt should generate different IV for each encryption", (t) => {
+  const testKey = "my-secret-key"
+  const testText = "Hello, World!"
+
+  const encrypted1 = aes.encrypt(testKey, testText)
+  const encrypted2 = aes.encrypt(testKey, testText)
+
+  t.not(encrypted1, encrypted2)
+  t.not(encrypted1.split(":")[0], encrypted2.split(":")[0])
+})
+
+test("aes.encrypt should encrypt empty string", (t) => {
+  const encrypted = aes.encrypt("key", "")
+
+  t.truthy(encrypted)
+  t.true(encrypted.includes(":"))
+})
+
+test("aes.encrypt should encrypt unicode text", (t) => {
+  const unicodeText = "你好世界 🌍"
+  const encrypted = aes.encrypt("key", unicodeText)
+
+  t.truthy(encrypted)
+  t.true(encrypted.includes(":"))
+})
+
+test("aes.decrypt should decrypt encrypted text correctly", (t) => {
+  const testKey = "my-secret-key"
+  const testText = "Hello, World!"
+
+  const encrypted = aes.encrypt(testKey, testText)
+  const decrypted = aes.decrypt(testKey, encrypted)
+
+  t.is(decrypted, testText)
+})
+
+test("aes.decrypt should decrypt empty string", (t) => {
+  const testKey = "my-secret-key"
+
+  const encrypted = aes.encrypt(testKey, "")
+  const decrypted = aes.decrypt(testKey, encrypted)
+
+  t.is(decrypted, "")
+})
+
+test("aes.decrypt should decrypt unicode text", (t) => {
+  const unicodeText = "你好世界 🌍"
+  const testKey = "my-secret-key"
+
+  const encrypted = aes.encrypt(testKey, unicodeText)
+  const decrypted = aes.decrypt(testKey, encrypted)
+
+  t.is(decrypted, unicodeText)
+})
+
+test("aes.decrypt should handle encrypted text with multiple colons in original", (t) => {
+  const testKey = "my-secret-key"
+  const textWithColons = "test:with:colons"
+
+  const encrypted = aes.encrypt(testKey, textWithColons)
+  const decrypted = aes.decrypt(testKey, encrypted)
+
+  t.is(decrypted, textWithColons)
+})
+
+test("aes.decrypt should throw error with wrong key", (t) => {
+  const testText = "Hello, World!"
+  const encrypted = aes.encrypt("correct-key", testText)
+
+  t.throws(() => {
+    aes.decrypt("wrong-key", encrypted)
+  })
+})
+
+test("aes.decrypt should throw error with invalid encrypted text", (t) => {
+  t.throws(() => {
+    aes.decrypt("key", "invalid:data")
+  })
+})
+
+// ==================== crypto.js - Hash 函数测试 ====================
+
+test("hash.md5 should generate MD5 hash", (t) => {
+  const result = hash.md5("Hello, World!")
+
+  t.is(result, "65a8e27d8879283831b664bd8b7f0ad4")
+  t.is(result.length, 32)
+})
+
+test("hash.md5 should generate MD5 hash for empty string", (t) => {
+  const result = hash.md5("")
+
+  t.is(result, "d41d8cd98f00b204e9800998ecf8427e")
+})
+
+test("hash.md5 should generate consistent MD5 hash", (t) => {
+  const text = "Test content"
+  const result1 = hash.md5(text)
+  const result2 = hash.md5(text)
+
+  t.is(result1, result2)
+})
+
+test("hash.sha1 should generate SHA1 hash", (t) => {
+  const result = hash.sha1("Hello, World!")
+
+  t.is(result, "0a0a9f2a6772942557ab5355d76af442f8f65e01")
+  t.is(result.length, 40)
+})
+
+test("hash.sha1 should generate SHA1 hash for empty string", (t) => {
+  const result = hash.sha1("")
+
+  t.is(result, "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+})
+
+test("hash.sha1 should generate consistent SHA1 hash", (t) => {
+  const text = "Test content"
+  const result1 = hash.sha1(text)
+  const result2 = hash.sha1(text)
+
+  t.is(result1, result2)
+})
+
+test("hash.sha3 should generate SHA3-256 hash with default prefix", (t) => {
+  const result = hash.sha3("Hello, World!")
+
+  t.regex(result, /^0x[a-f0-9]{64}$/)
+})
+
+test("hash.sha3 should generate SHA3-256 hash without prefix", (t) => {
+  const result = hash.sha3("Hello, World!", false)
+
+  t.regex(result, /^[a-f0-9]{64}$/)
+  t.false(result.startsWith("0x"))
+})
+
+test("hash.sha3 should generate SHA3-512 hash", (t) => {
+  const result = hash.sha3("Hello, World!", true, 512)
+
+  t.regex(result, /^0x[a-f0-9]{128}$/)
+})
+
+test("hash.sha3 should generate SHA3-224 hash", (t) => {
+  const result = hash.sha3("Hello, World!", true, 224)
+
+  t.regex(result, /^0x[a-f0-9]{56}$/)
+})
+
+test("hash.sha3 should generate SHA3-384 hash", (t) => {
+  const result = hash.sha3("Hello, World!", true, 384)
+
+  t.regex(result, /^0x[a-f0-9]{96}$/)
+})
+
+test("hash.sha3 should generate consistent SHA3 hash", (t) => {
+  const text = "Test content"
+  const result1 = hash.sha3(text)
+  const result2 = hash.sha3(text)
+
+  t.is(result1, result2)
+})
+
+test("hash.keccak256 should generate Keccak256 hash with 0x prefix", (t) => {
+  const result = hash.keccak256("Hello, World!")
+
+  t.regex(result, /^0x[a-f0-9]{64}$/)
+})
+
+test("hash.keccak256 should generate Keccak256 hash for empty string", (t) => {
+  const result = hash.keccak256("")
+
+  t.regex(result, /^0x[a-f0-9]{64}$/)
+})
+
+test("hash.keccak256 should generate consistent Keccak256 hash", (t) => {
+  const text = "Test content"
+  const result1 = hash.keccak256(text)
+  const result2 = hash.keccak256(text)
+
+  t.is(result1, result2)
+})
+
+test("hash.sha256 should generate SHA256 hash for string", (t) => {
+  const result = hash.sha256("Hello, World!")
+
+  t.is(
+    result,
+    "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f",
+  )
+  t.is(result.length, 64)
+})
+
+test("hash.sha256 should generate SHA256 hash for Buffer", (t) => {
+  const buffer = Buffer.from("Hello, World!")
+  const result = hash.sha256(buffer)
+
+  t.is(
+    result,
+    "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f",
+  )
+})
+
+test("hash.sha256 should generate SHA256 hash for Readable stream", async (t) => {
+  const stream = Readable.from(["Hello, World!"])
+  const result = await hash.sha256(stream)
+
+  t.is(
+    result,
+    "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f",
+  )
+})
+
+test("hash.sha256 should generate SHA256 hash for chunked stream", async (t) => {
+  const stream = Readable.from(["Hello", ", ", "World!"])
+  const result = await hash.sha256(stream)
+
+  t.is(
+    result,
+    "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f",
+  )
+})
+
+test("hash.sha256 should throw error for null input", (t) => {
+  const error = t.throws(() => {
+    hash.sha256(null)
+  })
+
+  t.is(error.message, "Input cannot be null or undefined")
+})
+
+test("hash.sha256 should throw error for undefined input", (t) => {
+  const error = t.throws(() => {
+    hash.sha256(undefined)
+  })
+
+  t.is(error.message, "Input cannot be null or undefined")
+})
+
+test("hash.sha256 should throw error for number input", (t) => {
+  const error = t.throws(() => {
+    hash.sha256(123)
+  })
+
+  t.is(error.message, "Input must be a string, Buffer, or Readable stream")
+})
+
+test("hash.sha256 should throw error for object input", (t) => {
+  const error = t.throws(() => {
+    hash.sha256({})
+  })
+
+  t.is(error.message, "Input must be a string, Buffer, or Readable stream")
+})
+
+test("hash.sha256 should reject promise on stream error", async (t) => {
+  const stream = new Readable({
+    read() {
+      this.emit("error", new Error("Stream error"))
+    },
+  })
+
+  await t.throwsAsync(async () => await hash.sha256(stream), {
+    message: "Stream error",
+  })
+})
+
+test("hash.sha256 should handle empty string", (t) => {
+  const result = hash.sha256("")
+
+  t.is(
+    result,
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  )
+})
+
+test("hash.rmd160 should generate RIPEMD-160 hash", (t) => {
+  const result = hash.rmd160("Hello, World!")
+
+  t.true(result instanceof Buffer)
+  t.is(result.length, 20)
+})
+
+test("hash.rmd160 should generate RIPEMD-160 hash for empty string", (t) => {
+  const result = hash.rmd160("")
+
+  t.true(result instanceof Buffer)
+  t.is(result.length, 20)
+})
+
+test("hash.rmd160 should generate consistent RIPEMD-160 hash", (t) => {
+  const text = "Test content"
+  const result1 = hash.rmd160(text)
+  const result2 = hash.rmd160(text)
+
+  t.true(result1.equals(result2))
+})
+
+test("hash.hmac should generate HMAC with default parameters (SHA256, base64)", (t) => {
+  const result = hash.hmac("Hello, World!", "my-secret")
+
+  t.is(typeof result, "string")
+  t.truthy(result)
+  t.regex(result, /^[A-Za-z0-9+/]+=*$/)
+})
+
+test("hash.hmac should generate HMAC with SHA256 and hex digest", (t) => {
+  const result = hash.hmac("Hello, World!", "my-secret", "SHA256", "hex")
+
+  t.regex(result, /^[a-f0-9]+$/)
+})
+
+test("hash.hmac should generate HMAC with SHA1", (t) => {
+  const result = hash.hmac("Hello, World!", "my-secret", "SHA1", "hex")
+
+  t.regex(result, /^[a-f0-9]+$/)
+})
+
+test("hash.hmac should generate HMAC with SHA512", (t) => {
+  const result = hash.hmac("Hello, World!", "my-secret", "SHA512", "hex")
+
+  t.regex(result, /^[a-f0-9]+$/)
+  t.is(result.length, 128)
+})
+
+test("hash.hmac should generate HMAC with base64 digest", (t) => {
+  const result = hash.hmac("Hello, World!", "my-secret", "SHA256", "base64")
+
+  t.regex(result, /^[A-Za-z0-9+/]+=*$/)
+})
+
+test("hash.hmac should generate consistent HMAC", (t) => {
+  const result1 = hash.hmac("Hello, World!", "my-secret")
+  const result2 = hash.hmac("Hello, World!", "my-secret")
+
+  t.is(result1, result2)
+})
+
+test("hash.hmac should generate different HMAC with different secrets", (t) => {
+  const result1 = hash.hmac("Hello, World!", "secret1")
+  const result2 = hash.hmac("Hello, World!", "secret2")
+
+  t.not(result1, result2)
+})
+
+test("base64 module should be exported", (t) => {
+  t.truthy(base64)
+  t.is(typeof base64, "object")
+})

--- a/test/utils/helper.test.mjs
+++ b/test/utils/helper.test.mjs
@@ -1,0 +1,149 @@
+import test from "ava"
+import { extractFileNameFromContentDisposition } from "../../server/utils/helper.mjs"
+
+test("extractFileNameFromContentDisposition should extract UTF-8 encoded filename with uppercase UTF-8", (t) => {
+  const header = "attachment; filename*=UTF-8''test%20file.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "test file.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract UTF-8 encoded filename with lowercase utf-8", (t) => {
+  const header = "attachment; filename*=utf-8''test%20file.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "test file.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract UTF-8 encoded filename with Chinese characters", (t) => {
+  const header =
+    "attachment; filename*=UTF-8''%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "测试文件.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract UTF-8 encoded filename with special characters", (t) => {
+  const header = "attachment; filename*=UTF-8''file%20%28copy%29.txt"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "file (copy).txt")
+})
+
+test("extractFileNameFromContentDisposition should handle malformed UTF-8 encoded filename", (t) => {
+  const header = "attachment; filename*=UTF-8''%ZZ%invalid"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "%ZZ%invalid")
+})
+
+test("extractFileNameFromContentDisposition should extract UTF-8 encoded filename with semicolon after", (t) => {
+  const header = "attachment; filename*=UTF-8''test.pdf; size=1024"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "test.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract quoted filename", (t) => {
+  const header = 'attachment; filename="document.pdf"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "document.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract unquoted filename", (t) => {
+  const header = "attachment; filename=document.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "document.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract filename with spaces in quotes", (t) => {
+  const header = 'attachment; filename="my document.pdf"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "my document.pdf")
+})
+
+test("extractFileNameFromContentDisposition should extract filename with special characters in quotes", (t) => {
+  const header = 'attachment; filename="file (copy).txt"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "file (copy).txt")
+})
+
+test("extractFileNameFromContentDisposition should extract unquoted filename with semicolon after", (t) => {
+  const header = "attachment; filename=test.pdf; size=1024"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "test.pdf")
+})
+
+test("extractFileNameFromContentDisposition should prioritize filename* over filename", (t) => {
+  const header =
+    "attachment; filename=\"fallback.pdf\"; filename*=UTF-8''priority.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "priority.pdf")
+})
+
+test("extractFileNameFromContentDisposition should return null for null input", (t) => {
+  const result = extractFileNameFromContentDisposition(null)
+
+  t.is(result, null)
+})
+
+test("extractFileNameFromContentDisposition should return null for undefined input", (t) => {
+  const result = extractFileNameFromContentDisposition(undefined)
+
+  t.is(result, null)
+})
+
+test("extractFileNameFromContentDisposition should return null for empty string", (t) => {
+  const result = extractFileNameFromContentDisposition("")
+
+  t.is(result, null)
+})
+
+test("extractFileNameFromContentDisposition should return null when no filename found", (t) => {
+  const header = "attachment; size=1024"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, null)
+})
+
+test("extractFileNameFromContentDisposition should handle filename with equals sign in value", (t) => {
+  const header = 'attachment; filename="file=name.pdf"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "file=name.pdf")
+})
+
+test("extractFileNameFromContentDisposition should handle filename with mixed case", (t) => {
+  const header = 'attachment; FileName="document.pdf"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "document.pdf")
+})
+
+test("extractFileNameFromContentDisposition should handle filename* with mixed case", (t) => {
+  const header = "attachment; FILENAME*=UTF-8''test.pdf"
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "test.pdf")
+})
+
+test("extractFileNameFromContentDisposition should handle whitespace around filename", (t) => {
+  const header = 'attachment; filename = "document.pdf"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "document.pdf")
+})
+
+test("extractFileNameFromContentDisposition should handle complex real-world header", (t) => {
+  const header =
+    'attachment; filename="report-2024.xlsx"; modification-date="Mon, 20 Oct 2025 12:00:00 GMT"'
+  const result = extractFileNameFromContentDisposition(header)
+
+  t.is(result, "report-2024.xlsx")
+})

--- a/test/utils/webpush.test.mjs
+++ b/test/utils/webpush.test.mjs
@@ -1,0 +1,116 @@
+// webpush.test.mjs
+import test from "ava"
+import sinon from "sinon"
+import webpush from "web-push"
+import { Setting } from "../../server/models/index.mjs"
+import { sendPushNotification } from "../../server/utils/webpush.mjs"
+
+test.beforeEach(() => {
+  sinon.restore()
+  // 保证 stub 存在，方便断言
+  sinon.stub(webpush, "setVapidDetails").returns()
+  sinon.stub(webpush, "sendNotification").resolves()
+})
+
+// --- Tests ---
+
+test.serial("should skip when VAPID keys are not configured", async (t) => {
+  sinon.stub(Setting, "get").withArgs("notification_vapid_keys").resolves(null)
+
+  await sendPushNotification({ msg: "hi" })
+  t.false(webpush.setVapidDetails.called)
+  t.false(webpush.sendNotification.called)
+})
+
+test.serial("should skip when subscriptions are missing", async (t) => {
+  sinon
+    .stub(Setting, "get")
+    .withArgs("notification_vapid_keys")
+    .resolves({ publicKey: "pub", privateKey: "priv" })
+  Setting.get.withArgs("notification_subscriptions").resolves(null)
+
+  await sendPushNotification({ msg: "no subs" })
+  t.false(webpush.setVapidDetails.called)
+  t.false(webpush.sendNotification.called)
+})
+
+test.serial("should skip when subscriptions array is empty", async (t) => {
+  sinon
+    .stub(Setting, "get")
+    .withArgs("notification_vapid_keys")
+    .resolves({ publicKey: "pub", privateKey: "priv" })
+  Setting.get.withArgs("notification_subscriptions").resolves([])
+
+  await sendPushNotification({ msg: "empty" })
+  t.false(webpush.setVapidDetails.called)
+  t.false(webpush.sendNotification.called)
+})
+
+test.serial("should send notification successfully", async (t) => {
+  const vapid = { publicKey: "pub", privateKey: "priv" }
+  const sub = { endpoint: "https://push.test/send" }
+
+  sinon.stub(Setting, "get").callsFake((key) => {
+    if (key === "notification_vapid_keys") return Promise.resolve(vapid)
+    if (key === "notification_subscriptions") return Promise.resolve([sub])
+  })
+
+  await sendPushNotification({ msg: "ok" })
+
+  t.true(webpush.setVapidDetails.calledOnce)
+  t.true(webpush.sendNotification.calledOnce)
+  t.deepEqual(webpush.sendNotification.firstCall.args[0], sub)
+})
+
+test.serial("should remove invalid subscriptions (404/410)", async (t) => {
+  const vapid = { publicKey: "pub", privateKey: "priv" }
+  const subs = [{ endpoint: "1" }, { endpoint: "2" }]
+
+  sinon.stub(Setting, "get").callsFake((key) => {
+    if (key === "notification_vapid_keys") return Promise.resolve(vapid)
+    if (key === "notification_subscriptions") return Promise.resolve(subs)
+  })
+  const setStub = sinon.stub(Setting, "set").resolves()
+  webpush.sendNotification.onFirstCall().rejects({ statusCode: 410 })
+  webpush.sendNotification.onSecondCall().resolves()
+
+  await sendPushNotification({ msg: "clean" })
+
+  t.true(setStub.calledOnce)
+  const validSubs = setStub.firstCall.args[1]
+  t.deepEqual(validSubs, [subs[1]])
+})
+
+test.serial("should continue when general send error occurs", async (t) => {
+  const vapid = { publicKey: "pub", privateKey: "priv" }
+  const sub = { endpoint: "err" }
+
+  sinon.stub(Setting, "get").callsFake((key) => {
+    if (key === "notification_vapid_keys") return Promise.resolve(vapid)
+    if (key === "notification_subscriptions") return Promise.resolve([sub])
+  })
+  webpush.sendNotification.rejects({ message: "fail", statusCode: 500 })
+
+  await t.notThrowsAsync(() => sendPushNotification({ msg: "fail" }))
+  t.true(webpush.sendNotification.calledOnce)
+})
+
+test.serial("should throw when subscriptions getter throws", async (t) => {
+  const vapid = { publicKey: "pub", privateKey: "priv" }
+
+  sinon.stub(Setting, "get").callsFake((key) => {
+    if (key === "notification_vapid_keys") return Promise.resolve(vapid)
+    if (key === "notification_subscriptions") throw new Error("parse error")
+  })
+
+  await t.throwsAsync(() => sendPushNotification({ msg: "parse" }), {
+    message: "parse error",
+  })
+})
+
+test.serial("should rethrow unexpected errors", async (t) => {
+  sinon.stub(Setting, "get").rejects(new Error("unexpected"))
+  await t.throwsAsync(() => sendPushNotification({ msg: "boom" }), {
+    message: "unexpected",
+  })
+})


### PR DESCRIPTION
This commit introduces a web push notification system to alert node owners in real-time when a new visitor connects to their node. This enhances user experience by providing immediate feedback without needing to have the application window open.

Key Changes:

Backend:
- Dependency: Added the web-push library to handle VAPID-based push message sending.
- Installation & Configuration:
    - During node installation (/api/install), VAPID key pairs are now automatically generated and stored in the settings table under the notification_vapid_keys key.
    - The Setting model has been updated to automatically handle JSON serialization for notification_vapid_keys and notification_subscriptions.
- GraphQL API:
    - The settings query now exposes the vapidPublicKey, which is accessible to all users for subscribing to notifications.
    - Added subscribeNotification mutation to allow authenticated users to save their PushSubscription object. It handles both new subscriptions and updates to existing ones based on the endpoint.
    - Added unsubscribeNotification mutation for users to remove their subscriptions.
- Notification Trigger:
    - A new server/utils/webpush.mjs utility encapsulates the logic for sending notifications. It gracefully handles errors and removes expired subscriptions.
    - The POST /api/visitors endpoint now identifies new visitors and asynchronously calls sendPushNotification to alert the node owner.

Frontend:
- Service Worker: A new service worker (client/public/sw.js) is added to listen for incoming push events and display notifications. It also handles notificationclick events to focus the client window.
- Subscription Management:
    - A PushNotificationContext and a usePushNotification hook are introduced to manage the subscription lifecycle (checking status, subscribing, unsubscribing).
    - A helper utility client/utils/helpers/pushNotification.js contains the core client-side logic for interacting with the Push API.
- UI/UX:
    - The main page layout now includes the PushNotificationProvider.
    - A new section in the settings page allows users to manage their notification subscription status.
    - Added i18n translations for new UI elements in both English (en.json) and Chinese (zh.json).

Testing:
- Added comprehensive end-to-end tests for the new notification feature:
    - Verified VAPID key generation during installation.
    - Tested the subscribeNotification and unsubscribeNotification mutations for various scenarios.
    - Added tests for the settings query to ensure vapidPublicKey is exposed correctly.
    - Included tests for the POST /api/visitors endpoint to confirm that push notifications are triggered for new visitors.
    - Created tests for the webpush.mjs utility to cover different sending scenarios, including error handling and cleanup of invalid subscriptions.

Closes #150