### PR TITLE
feat(client): Standardize LoadMoreButton spacing and improve flexibility

### DIFF
--- a/client/components/ui/button/LoadMoreButton.jsx
+++ b/client/components/ui/button/LoadMoreButton.jsx
@@ -29,12 +29,13 @@ export function LoadMoreButton({
   onLoadMore,
   showNoMore = true,
   hasAttemptedLoadMore = false,
+  ...props
 }) {
   const { t } = useIntl()
 
   if (hasMore) {
     return (
-      <Box textAlign="center" pt={2}>
+      <Box textAlign="center">
         <Button
           onClick={onLoadMore}
           loading={loading}
@@ -43,6 +44,7 @@ export function LoadMoreButton({
           w="full"
           block
           disabled={loading}
+          {...props}
         >
           {t("common.loadMore")} <LuEllipsis />
         </Button>
@@ -52,8 +54,13 @@ export function LoadMoreButton({
 
   if (showNoMore && hasAttemptedLoadMore) {
     return (
-      <Box textAlign="center" pt={2}>
-        <Text color="gray.400" _dark={{ color: "gray.500" }} fontSize="sm">
+      <Box textAlign="center">
+        <Text
+          color="gray.400"
+          _dark={{ color: "gray.500" }}
+          fontSize="sm"
+          {...props}
+        >
           {t("common.noMore")}
         </Text>
       </Box>


### PR DESCRIPTION
Closes #153

Removes the hardcoded top padding from the `LoadMoreButton` component, allowing the parent component to control the spacing. This helps to standardize the button's appearance across different content list pages.

Additionally, the component now accepts and passes through extra props to the underlying Chakra UI `Button` and `Text` components, increasing its flexibility and reusability.