### PR TITLE
fix(server): Correct GraphiQL access path

### DIFF
--- a/server/graphql/index.mjs
+++ b/server/graphql/index.mjs
@@ -13,7 +13,7 @@ const { plugin, Loader, type } = graphql
 export default function () {
   return plugin({
     graphiql: true,
-    path: "/api/graphql",
+    prefix: "/api",
     allowBatchedQueries: true,
     context: async (request, reply) => {
       // request.user is already populated by the preHandler hook


### PR DESCRIPTION
GraphiQL was not accessible via /api/graphiql due to an incorrect path configuration.
Changed 'path' to 'prefix' in the GraphQL plugin options to correctly expose the GraphiQL interface under the /api route.
This resolves the issue where the GraphiQL IDE was enabled but not reachable, allowing for interactive API testing.

Closes #173